### PR TITLE
Add certificate management documentation

### DIFF
--- a/docs/clustering/certificate-management.md
+++ b/docs/clustering/certificate-management.md
@@ -46,15 +46,15 @@ X509v3 Extended Key Usage:
 If you are having TLS issues with clustering, use the following steps to verify that your certificates are valid.
 
 1. Make sure certificates can be parsed and that you can view the contents:
-~~~
+```
 openssl x509 -in <certificate>.pem -noout -text`
-~~~
+```
 2. Make sure the certificate validates with the CA:
-~~~
+```
 openssl verify -CAfile <certificateAuthority>.pem <certificate>.pem`
-~~~
+```
 3. Make sure the certificate and private key are a valid pair by verifying that the output of the following commands match:
-~~~
+```
 openssl rsa -modulus -noout -in <privateKey>.pem | openssl md5
 openssl x509 -modulus -noout -in <certificate>.pem | openssl md5
-~~~
+```

--- a/docs/security/certificate-management.md
+++ b/docs/security/certificate-management.md
@@ -21,20 +21,20 @@ We have a few recommended options for enabling HTTPS in a production setting.
 To enable HTTPS, set the `operationsApi.network.https` and `customFunctions.network.https` to `true` and restart HarperDB.
 
 To replace the certificates, either replace the contents of the existing certificate files at `<ROOTPATH>/keys/`, or update the HarperDB configuration with the path of your new certificate files, and then restart HarperDB.
-~~~yaml
+```yaml
 operationsApi:
   tls:
     certificate: ~/hdb/keys/certificate.pem
     certificateAuthority: ~/hdb/keys/ca.pem
     privateKey: ~/hdb/keys/privateKey.pem
-~~~
-~~~yaml
+```
+```yaml
 customFunctions:
   tls:
     certificate: ~/hdb/keys/certificate.pem
     certificateAuthority: ~/hdb/keys/ca.pem
     privateKey: ~/hdb/keys/privateKey.pem
-~~~
+```
 
 ### Option: Nginx Reverse Proxy
 


### PR DESCRIPTION
This is just a first edition. I think it covers most of the basics of how we expect people to use certificates for HarperDB for clustering & serving up their APIs. We should definitely build on this more as we learn more but I think something like this is better than no information about it.

Please either suggest edits or make comments or whatever is easiest for you.

Let me know where you think we could add more info, re-word to be better, etc.