### PR TITLE
DOCS-11: added clustering.logLevel to the config page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -433,7 +433,7 @@ Control the verbosity of logs.
 logging:
   level: error
 ```
-There exists a log level hierarchy in order as `trace`, `debug`, `info`, `warn`, and `error`. When the level is set to `trace` logs will be created for all possible levels. Whereas if the level is set to `warn`, the only entries logged will be `warn` and `error`. The default value is `error`.
+There exists a log level hierarchy in order as `trace`, `debug`, `info`, `warn`, `error`, `fatal`, and `notify`. When the level is set to `trace` logs will be created for all possible levels. Whereas if the level is set to `fatal`, the only entries logged will be `fatal` and `notify`. The default value is `error`.
 
 `root` - _Type_: string; _Default_: &lt;ROOTPATH>/log
 


### PR DESCRIPTION
this pr adds a newer, previously undocumented config setting to the config file page in our documentation: clustering.logLevel. I also took this opportunity to remove deprecated log levels: fatal and notify from the logging section.