### PR TITLE
Clarified host value explanation for add and update ssh key

### DIFF
--- a/docs/developers/operations-api/components.md
+++ b/docs/developers/operations-api/components.md
@@ -47,10 +47,12 @@ or this can be shortened to:
 HarperDB/application-template#semver:v1.0.0
 ```
 
-You can also install from private repository if you have an installed SSH keys on the server:
+You can also install from private repository if you have installed SSH keys on the server. Ensure the `host` portion of the url exactly matches the `host` used when adding ssh keys to ensure proper authentication.
 
 ```
 git+ssh://git@github.com:my-org/my-app.git#semver:v1.0.0
+
+git+ssh://git@harperdb-private-component.github.com:my-org/my-app.git#semver:v1.0.0
 ```
 
 Or you can use a Github token:
@@ -328,7 +330,7 @@ _Operation is restricted to super_user roles only_
 - operation _(required)_ - must always be `add_ssh_key`
 - name _(required)_ - the name of the key
 - key _(required)_ - the private key contents. Must be an ed25519 key. Line breaks must be delimited with `\n` and have a trailing `\n`
-- host _(required)_ - the host for the ssh config (see below). Used as part of the `package` url when deploying a component using this key. It must match the host portion of the `package` url for the component (ex: host for git@github.com url is `github.com`)
+- host _(required)_ - the host for the ssh config (see below). Used as part of the `package` url when deploying a component using this key.
 - hostname _(required)_ - the hostname for the ssh config (see below). Used to map `host` to an actual domain (e.g. `github.com`)
 - known_hosts _(optional)_ - the public SSH keys of the host your component will be retrieved from. If `hostname` is `github.com` this will be retrieved automatically. Line breaks must be delimited with `\n`
 - replicated _(optional)_ - if true, HarperDB will replicate the key to all nodes in the cluster. Must be a boolean.
@@ -340,7 +342,7 @@ _Operation is restricted to super_user roles only_
 	"operation": "add_ssh_key",
 	"name": "harperdb-private-component",
 	"key": "-----BEGIN OPENSSH PRIVATE KEY-----\nthis\nis\na\nfake\nkey\n-----END OPENSSH PRIVATE KEY-----\n",
-	"host": "github.com",
+	"host": "harperdb-private-component.github.com",
 	"hostname": "github.com"
 }
 ```
@@ -357,7 +359,7 @@ _Operation is restricted to super_user roles only_
 
 ```
 #harperdb-private-component
-Host github.com
+Host harperdb-private-component.github.com
         HostName github.com
         User git
         IdentityFile /hdbroot/ssh/harperdb-private-component.key
@@ -367,7 +369,7 @@ Host github.com
 ```
 "package": "git+ssh://git@<host>:<github-repo-path>.git#semver:v1.2.3"
 
-"package": "git+ssh://git@github.com:HarperDB/harperdb-private-component.git#semver:v1.2.3"
+"package": "git+ssh://git@harperdb-private-component.github.com:HarperDB/harperdb-private-component.git#semver:v1.2.3"
 ```
 
 Note that `deploy_component` with a package uses `npm install` so the url must be a valid npm format url. The above is an example of a url using a tag in the repo to install.
@@ -383,7 +385,7 @@ _Operation is restricted to super_user roles only_
 - operation _(required)_ - must always be `update_ssh_key`
 - name _(required)_ - the name of the key to be updated
 - key _(required)_ - the private key contents. Must be an ed25519 key. Line breaks must be delimited with `\n` and have a trailing `\n`
-- host _(required)_ - the host for the ssh config (see below). Used as part of the `package` url when deploying a component using this key. It must match the host portion of the `package` url for the component (ex: host for git@github.com url is `github.com`)
+- host _(required)_ - the host for the ssh config (see below). Used as part of the `package` url when deploying a component using this key.
 - hostname _(required)_ - the hostname for the ssh config (see below). Used to map `host` to an actual domain (e.g. `github.com`)
 - known_hosts _(optional)_ - the public SSH keys of the host your component will be retrieved from. If `hostname` is `github.com` this will be retrieved automatically. Line breaks must be delimited with `\n`
 - replicated _(optional)_ - if true, HarperDB will replicate the key to all nodes in the cluster. Must be a boolean.
@@ -395,7 +397,7 @@ _Operation is restricted to super_user roles only_
 	"operation": "update_ssh_key",
 	"name": "harperdb-private-component",
 	"key": "-----BEGIN OPENSSH PRIVATE KEY-----\nthis\nis\na\nNEWFAKE\nkey\n-----END OPENSSH PRIVATE KEY-----\n",
-	"host": "github.com",
+	"host": "harperdb-private-component.github.com",
 	"hostname": "github.com"
 }
 ```


### PR DESCRIPTION
Attempted to deploy component using api and cli following docs and ran into github public key permission errors. Found that `package.json` used `git@github.com` when attempting to authenticate based on package url provided in `deploy_component` request. However, original `host` value instructions for `add_ssh_key` direct user to enter `private-repo-name.github.com` to create the config file, which would require calling `git@private-repo-name.github.com` instead in order to access the associated private key in config.

I can recreate and demo if needed for clarification.

If we specifically need to support `private-repo-name.github.com` as host in config then package name in `package.json` would need to be modified to match `git@private-repo-name.github.com` or a custom git script added to ensure proper key is used.

_Also removed a redundant section of docs for clarity_