### PR TITLE
add gh pages template from docusaurus

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - docs-in-hdb
-      - gh-pages-workflow
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -76,7 +75,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     # Only deploy on push to specific branches, not on PRs
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs-in-hdb' || github.ref == 'refs/heads/gh-pages-workflow')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs-in-hdb')
 
     permissions:
       pages: write


### PR DESCRIPTION
Unsure how accurate this is but good enough starting point: https://docusaurus.io/docs/deployment#deploying-to-github-pages

Notably, my editor warns on the `jobs.deploy.environment.name` that `github-pages` is invalid:

```
Value 'github-pages' is not valid
The name of the environment used by the job.

Available expression contexts: github, inputs, vars, needs, strategy, matrix
```

So not sure what to do there. Anyways, this likely wont work until we do the actual replatform and enable gh pages for this repo. We will likely have to iterate on `main` anyways to get the workflow to properly work.