### PR TITLE
format fix and pulling in .prettierrc.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+	"useTabs": true,
+	"printWidth": 120,
+	"singleQuote": true,
+	"trailingComma": "es5",
+	"quoteProps": "consistent"
+}

--- a/release-notes/v4-tucker/4.6.8.md
+++ b/release-notes/v4-tucker/4.6.8.md
@@ -10,4 +10,4 @@ title: 4.6.8
 - Throttling of non-safe HTTP requests and cache resolutions
 - Fix for skipping application of field select() after a custom get method
 - Fix for applying the correct permissions when deploying from Windows
-- Disable fail-over handling by default for replication 
+- Disable fail-over handling by default for replication


### PR DESCRIPTION
this is just the same prettierrc we have elsewhere but in testing with vscode the ide seems to only 'format on save' if this file exists...