### PR TITLE
Remove redundant and slightly different nav

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,24 +6,4 @@ title: Reference
 
 This section contains technical details and reference materials for Harper.
 
-- [Analytics](reference/analytics)
-- [Architecture](reference/architecture)
-- [Blob](reference/blob)
-- [Content Types](reference/content-types)
-- [Components](reference/components/)
-  - [Applications](reference/components/applications)
-  - [Built-In Extensions](reference/components/built-in-extensions)
-  - [Configuration](reference/components/configuration)
-  - [Extensions](reference/components/extensions)
-  - [(Experimental) Plugins](reference/components/plugins)
-- [Data Types](reference/data-types)
-- [Dynamic Schema](reference/dynamic-schema)
-- [Globals](reference/globals)
-- [GraphQL](reference/graphql)
-- [Headers](reference/headers)
-- [Limits](reference/limits)
-- [Resources](reference/resources/)
-  - [Migration](reference/resources/migration)
-  - [Instance Binding](reference/resources/instance-binding)
-- [Storage Algorithm](reference/storage-algorithm)
-- [Transactions](reference/transactions)
+Please choose a topic from the navigation menu on the left.


### PR DESCRIPTION
...from main Reference page. This will be hard to keep in sync (and is already not 100% in sync) and is pretty redundant with the left nav.


If we agree this is a good idea, I'll apply it to the versioned docs too.