### PR TITLE
Hide version dropdown on non-versioned paths

### DIFF
--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -3,12 +3,12 @@ import DocsVersionDropdownNavbarItem from '@theme-original/NavbarItem/DocsVersio
 import { useLocation } from '@docusaurus/router';
 import type { Props } from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
 
-function checkPathname(pathname: string) {
+function isNonVersionedPathname(pathname: string) {
 	return pathname.startsWith('/fabric') || pathname.startsWith('/release-notes');
 }
 
 export default function DocsVersionDropdownNavbarItemWrapper(props: Props) {
 	const location = useLocation();
 
-	return checkPathname(location.pathname) ? null : <DocsVersionDropdownNavbarItem {...props} />;
+	return isNonVersionedPathname(location.pathname) ? null : <DocsVersionDropdownNavbarItem {...props} />;
 }


### PR DESCRIPTION
Hides the version dropdown in the navbar when on a non-versioned path such as `/release-notes` or `/fabric`. Works on all subpaths too. 

Before:
<img width="2232" height="124" alt="Screenshot 2025-11-25 at 9 26 21 AM" src="https://github.com/user-attachments/assets/c7f4c6d6-3106-4795-b0b5-a10bf0ea2476" />

After: 
<img width="2230" height="114" alt="Screenshot 2025-11-25 at 9 25 20 AM" src="https://github.com/user-attachments/assets/ccea423c-eddc-4224-812a-93071ee299fd" />

> Search bars are different due to different search components on the live site and local development. 

Found solution for this here: https://github.com/facebook/docusaurus/issues/4389#issuecomment-1962954701