### PR TITLE
Harper naming updates

### DIFF
--- a/reference/components/applications.md
+++ b/reference/components/applications.md
@@ -23,7 +23,7 @@ Harper offers several approaches to managing applications that differ between lo
 The quickest way to run an application locally is with the `dev` command inside the application directory:
 
 ```sh
-harperdb dev .
+harper dev .
 ```
 
 The `dev` command watches for file changes and restarts Harper worker threads automatically.
@@ -36,11 +36,11 @@ Stop either process with SIGINT (Ctrl+C).
 
 To mimic interaction with a hosted Harper instance locally:
 
-1. Start Harper: `harperdb`
+1. Start Harper: `harper`
 2. Deploy the application:
 
    ```sh
-   harperdb deploy \
+   harper deploy \
      project=<name> \
      package=<path-to-project> \
      restart=true
@@ -50,15 +50,15 @@ To mimic interaction with a hosted Harper instance locally:
    - Setting `package=<path-to-project>` creates a symlink so file changes are picked up automatically between restarts.
    - `restart=true` restarts worker threads after deploy. Use `restart=rolling` for a rolling restart.
 
-3. Use `harperdb restart` in another terminal to restart threads at any time.
-4. Remove an application: `harperdb drop_component project=<name>`
+3. Use `harper restart` in another terminal to restart threads at any time.
+4. Remove an application: `harper drop_component project=<name>`
 
 > Not all [component operations](#operations-api) are available via CLI. When in doubt, use the Operations API via direct HTTP requests to the local Harper instance.
 
 Example:
 
 ```sh
-harperdb deploy \
+harper deploy \
   project=test-application \
   package=/Users/dev/test-application \
   restart=true
@@ -71,7 +71,7 @@ harperdb deploy \
 Managing applications on a remote Harper instance uses the same operations as local management. The key difference is specifying a `target` along with credentials:
 
 ```sh
-harperdb deploy \
+harper deploy \
   project=<name> \
   package=<package> \
   username=<username> \
@@ -86,7 +86,7 @@ Credentials can also be provided via environment variables:
 ```sh
 export CLI_TARGET_USERNAME=<username>
 export CLI_TARGET_PASSWORD=<password>
-harperdb deploy \
+harper deploy \
   project=<name> \
   package=<package> \
   target=<remote> \
@@ -121,13 +121,13 @@ Harper uses `npm` and `package.json` for dependency management.
 During application loading, Harper follows this resolution order to determine how to install dependencies:
 
 1. If `node_modules` exists, or if `package.json` is absent — skip installation
-2. Check the application's `harperdb-config.yaml` for `install: { command, timeout }` fields
+2. Check the application's `harper-config.yaml` for `install: { command, timeout }` fields
 3. Derive the package manager from [`package.json#devEngines#packageManager`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#devengines)
 4. Default to `npm install`
 
 The `add_component` and `deploy_component` operations support `install_command` and `install_timeout` fields for customizing this behavior.
 
-### Example `harperdb-config.yaml` with Custom Install
+### Example `harper-config.yaml` with Custom Install
 
 ```yaml
 myApp:
@@ -155,9 +155,9 @@ myApp:
 
 > If you plan to use an alternative package manager, ensure it is installed on the host machine. Harper does not support the `"onFail": "download"` option and falls back to `"onFail": "error"` behavior.
 
-## Advanced: Direct `harperdb-config.yaml` Configuration
+## Advanced: Direct `harper-config.yaml` Configuration
 
-Applications can be added to Harper by adding them directly to `harperdb-config.yaml` (located in the Harper `rootPath`, typically `~/hdb`).
+Applications can be added to Harper by adding them directly to `harper-config.yaml` (located in the Harper `rootPath`, typically `~/hdb`).
 
 ```yaml
 status-check:
@@ -172,7 +172,7 @@ Any valid npm dependency specifier works:
 myGithubComponent:
   package: HarperDB-Add-Ons/package#v2.2.0
 myNPMComponent:
-  package: harperdb
+  package: harper
 myTarBall:
   package: /Users/harper/cool-component.tar
 myLocal:
@@ -183,7 +183,7 @@ myWebsite:
 
 Harper generates a `package.json` and installs all components into `<componentsRoot>` (default: `~/hdb/components`). A symlink back to `<rootPath>/node_modules` is created for dependency resolution.
 
-> Use `harperdb get_configuration` to find the `rootPath` and `componentsRoot` values on your instance.
+> Use `harper get_configuration` to find the `rootPath` and `componentsRoot` values on your instance.
 
 ## Operations API
 
@@ -264,7 +264,7 @@ Packages a project folder as a base64-encoded `.tar` string.
 
 ### `get_components`
 
-Returns all local component files, folders, and configuration from `harperdb-config.yaml`.
+Returns all local component files, folders, and configuration from `harper-config.yaml`.
 
 ```json
 {

--- a/reference/components/extension-api.md
+++ b/reference/components/extension-api.md
@@ -41,7 +41,7 @@ A Resource Extension processes specific files or directories. It is comprised of
 | `setupFile()`       | Main thread only   | Once, at initial start    |
 | `setupDirectory()`  | Main thread only   | Once, at initial start    |
 
-> **Important**: `harperdb restart` only restarts worker threads. Code in `setupFile()` and `setupDirectory()` runs only when Harper fully shuts down and starts again—not on `deploy` or `restart`.
+> **Important**: `harper restart` only restarts worker threads. Code in `setupFile()` and `setupDirectory()` runs only when Harper fully shuts down and starts again—not on `deploy` or `restart`.
 
 `handleFile()` and `setupFile()` have identical signatures. `handleDirectory()` and `setupDirectory()` have identical signatures.
 

--- a/reference/components/plugin-api.md
+++ b/reference/components/plugin-api.md
@@ -82,10 +82,10 @@ customPlugin:
 
 ## TypeScript Support
 
-All classes and types are exported from the `harperdb` package:
+All classes and types are exported from the `harper` package:
 
 ```typescript
-import type { Scope, Config } from 'harperdb';
+import type { Scope, Config } from 'harper';
 ```
 
 ## API Reference

--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -11,7 +11,7 @@ title: Configuration Options
 
 # Configuration Options
 
-Quick reference for all `harperdb-config.yaml` top-level sections.
+Quick reference for all `harper-config.yaml` top-level sections.
 
 For how to apply configuration (YAML file, environment variables, CLI, Operations API), see [Configuration Overview](./overview.md).
 
@@ -328,7 +328,7 @@ applications:
 
 ## Component Configuration
 
-Installed components are configured directly at the root of `harperdb-config.yaml` using the component name as the key — not nested under a `components:` section. See [Components](../components/overview.md).
+Installed components are configured directly at the root of `harper-config.yaml` using the component name as the key — not nested under a `components:` section. See [Components](../components/overview.md).
 
 ```yaml
 my-component:

--- a/reference/configuration/overview.md
+++ b/reference/configuration/overview.md
@@ -7,7 +7,7 @@ title: Configuration Overview
 
 # Configuration
 
-Harper is configured through a [YAML](https://yaml.org/) file called `harperdb-config.yaml` located in the Harper root directory. By default the root directory is a folder named `hdb` in the home directory of the current user.
+Harper is configured through a [YAML](https://yaml.org/) file called `harper-config.yaml` located in the Harper root directory. By default the root directory is a folder named `hdb` in the home directory of the current user.
 
 Some configuration values are pre-populated in the config file on install, regardless of whether they are used.
 
@@ -17,7 +17,7 @@ For a complete reference of all available configuration options, see [Configurat
 
 ## The Configuration File
 
-To change a configuration value, edit `harperdb-config.yaml` and save. **Harper must be restarted for changes to take effect.**
+To change a configuration value, edit `harper-config.yaml` and save. **Harper must be restarted for changes to take effect.**
 
 Configuration keys use camelCase (e.g. `operationsApi`). Nested keys use dot notation conceptually (e.g. `operationsApi.network.port`).
 
@@ -29,7 +29,7 @@ All configuration values can be set through four mechanisms:
 
 ### 1. YAML File (direct edit)
 
-Edit `harperdb-config.yaml` directly:
+Edit `harper-config.yaml` directly:
 
 ```yaml
 http:
@@ -49,7 +49,7 @@ Examples:
 - `operationsApi.network.port` → `OPERATIONSAPI_NETWORK_PORT=9925`
 
 ```bash
-HTTP_PORT=9926 harperdb
+HTTP_PORT=9926 harper
 ```
 
 > **Note:** Component configuration cannot be set via environment variables or CLI arguments.
@@ -59,7 +59,7 @@ HTTP_PORT=9926 harperdb
 Same naming convention as environment variables, prefixed with `--`:
 
 ```bash
-harperdb --HTTP_PORT 9926 --LOGGING_LEVEL warn
+harper --HTTP_PORT 9926 --LOGGING_LEVEL warn
 ```
 
 ### 4. Operations API
@@ -84,10 +84,10 @@ To specify a custom config file location at install time, use the `HDB_CONFIG` v
 
 ```bash
 # Use a custom config file path
-HDB_CONFIG=/path/to/custom-config.yaml harperdb
+HDB_CONFIG=/path/to/custom-config.yaml harper
 
 # Install over an existing config
-HDB_CONFIG=/existing/rootpath/harperdb-config.yaml harperdb
+HDB_CONFIG=/existing/rootpath/harper-config.yaml harper
 ```
 
 ---
@@ -96,7 +96,7 @@ HDB_CONFIG=/existing/rootpath/harperdb-config.yaml harperdb
 
 <VersionBadge version="v4.7.2" />
 
-Harper provides two special environment variables for managing configuration across deployments: `HARPER_DEFAULT_CONFIG` and `HARPER_SET_CONFIG`. Both accept JSON-formatted configuration that mirrors the structure of `harperdb-config.yaml`.
+Harper provides two special environment variables for managing configuration across deployments: `HARPER_DEFAULT_CONFIG` and `HARPER_SET_CONFIG`. Both accept JSON-formatted configuration that mirrors the structure of `harper-config.yaml`.
 
 ```bash
 export HARPER_DEFAULT_CONFIG='{"http":{"port":8080},"logging":{"level":"info"}}'
@@ -123,7 +123,7 @@ Provides default configuration values while respecting user modifications. Ideal
 
 ```bash
 export HARPER_DEFAULT_CONFIG='{"http":{"port":8080},"logging":{"level":"info"}}'
-harperdb
+harper
 
 # If an administrator manually changes the port to 9000, Harper will
 # detect this edit and respect it on subsequent restarts.
@@ -146,9 +146,9 @@ Forces configuration values that cannot be overridden by user edits. Designed fo
 
 ```bash
 export HARPER_SET_CONFIG='{"authentication":{"enabled":true},"logging":{"level":"error","stdStreams":true}}'
-harperdb
+harper
 
-# Any change to these values in harperdb-config.yaml will be
+# Any change to these values in harper-config.yaml will be
 # overridden on the next restart.
 ```
 
@@ -203,7 +203,7 @@ logging:
 
 ### Important Notes
 
-- Both variables must contain valid JSON matching the structure of `harperdb-config.yaml`
+- Both variables must contain valid JSON matching the structure of `harper-config.yaml`
 - Invalid values are caught by Harper's configuration validator at startup
 - Changes to these variables require a Harper restart to take effect
 - The state file is per-instance (stored in the root path)

--- a/reference/database/api.md
+++ b/reference/database/api.md
@@ -96,7 +96,7 @@ For most operations — HTTP request handlers, for example — Harper automatica
 ### Basic Usage
 
 ```javascript
-import { tables } from 'harperdb';
+import { tables } from 'harper';
 const { MyTable } = tables;
 
 if (isMainThread) {

--- a/reference/database/compaction.md
+++ b/reference/database/compaction.md
@@ -24,7 +24,7 @@ Creates a compacted copy of a database file. The original database is left uncha
 Run using the [CLI](../cli/commands.md):
 
 ```bash
-harperdb copy-db <source-database> <target-database-path>
+harper copy-db <source-database> <target-database-path>
 ```
 
 The `source-database` is the database name (not a file path). The target is the full file path where the compacted copy will be written.
@@ -34,14 +34,14 @@ To replace the original database with the compacted copy, move or rename the out
 **Example — compact the default `data` database:**
 
 ```bash
-harperdb copy-db data /home/user/hdb/database/copy.mdb
+harper copy-db data /home/user/hdb/database/copy.mdb
 ```
 
 ## Compact on Start
 
 Automatically compacts all non-system databases when Harper starts. Harper will not start until compaction is complete. Under the hood, it loops through all user databases, creates a backup of each, compacts it, replaces the original with the compacted copy, and removes the backup.
 
-Configure in `harperdb-config.yaml`:
+Configure in `harper-config.yaml`:
 
 ```yaml
 storage:
@@ -52,7 +52,7 @@ storage:
 Using CLI environment variables:
 
 ```bash
-STORAGE_COMPACTONSTART=true STORAGE_COMPACTONSTARTKEEPBACKUP=true harperdb
+STORAGE_COMPACTONSTART=true STORAGE_COMPACTONSTARTKEEPBACKUP=true harper
 ```
 
 ### Options

--- a/reference/database/transaction.md
+++ b/reference/database/transaction.md
@@ -29,7 +29,7 @@ Available since: v4.1.0
 
 The audit log is a data store that tracks every transaction across all tables in a database. Harper automatically creates and maintains a single audit log per database. The audit log captures the operation type, the user who made the change, the timestamp, and both the new and original record values.
 
-The audit log is **enabled by default**. To disable it, set [`logging.auditLog`](../logging/configuration.md) to `false` in `harperdb-config.yaml` and restart Harper.
+The audit log is **enabled by default**. To disable it, set [`logging.auditLog`](../logging/configuration.md) to `false` in `harper-config.yaml` and restart Harper.
 
 > The audit log is required for real-time messaging (WebSocket and MQTT subscriptions) and replication. Do not disable it if real-time features or replication are in use.
 

--- a/reference/fastify-routes/overview.md
+++ b/reference/fastify-routes/overview.md
@@ -118,7 +118,7 @@ Executes a request against Harper without any security checks around whether the
 
 ### logger
 
-This helper allows you to write directly to the log file, hdb.log. It's useful for debugging during development, although you may also use the console logger. There are 5 functions contained within logger, each of which pertains to a different **logging.level** configuration in your harperdb-config.yaml file.
+This helper allows you to write directly to the log file, hdb.log. It's useful for debugging during development, although you may also use the console logger. There are 5 functions contained within logger, each of which pertains to a different **logging.level** configuration in your harper-config.yaml file.
 
 - logger.trace('Starting the handler for /dogs')
 - logger.debug('This should only fire once')

--- a/reference/http/api.md
+++ b/reference/http/api.md
@@ -186,7 +186,7 @@ server.upgrade(
 	(request, socket, head, next) => {
 		if (request.url === '/_next/webpack-hmr') {
 			return upgradeHandler(request, socket, head).then(() => {
-				request.__harperdb_request_upgraded = true;
+				request.__harperRequestUpgraded = true;
 				next(request, socket, head);
 			});
 		}
@@ -196,7 +196,7 @@ server.upgrade(
 );
 ```
 
-When `server.ws()` is registered, Harper adds a default upgrade handler. The default handler sets `request.__harperdb_request_upgraded = true` after upgrading, and checks for this flag before upgrading again (so external upgrade handlers can detect whether Harper has already handled the upgrade).
+When `server.ws()` is registered, Harper adds a default upgrade handler. The default handler sets `request.__harperRequestUpgraded = true` after upgrading, and checks for this flag before upgrading again (so external upgrade handlers can detect whether Harper has already handled the upgrade).
 
 ### `UpgradeListener`
 

--- a/reference/http/api.md
+++ b/reference/http/api.md
@@ -330,7 +330,7 @@ Metrics are aggregated and available via the [analytics API](../analytics/overvi
 
 ## `server.config`
 
-The parsed `harperdb-config.yaml` configuration object. Read-only access to Harper's current runtime configuration.
+The parsed `harper-config.yaml` configuration object. Read-only access to Harper's current runtime configuration.
 
 ---
 
@@ -371,7 +371,7 @@ A [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Glob
 Register or replace a handler by setting it on the `contentTypes` map:
 
 ```js
-import { contentTypes } from 'harperdb';
+import { contentTypes } from 'harper';
 
 contentTypes.set('text/xml', {
 	serialize(data) {

--- a/reference/http/configuration.md
+++ b/reference/http/configuration.md
@@ -8,7 +8,7 @@ title: HTTP Configuration
 <!-- Source: release-notes/v4-tucker/4.2.0.md (confirmed http section expansion, compressionThreshold, securePort, tls section) -->
 <!-- Source: release-notes/v4-tucker/4.5.0.md (confirmed http2 support) -->
 
-The `http` section in `harperdb-config.yaml` controls the built-in HTTP server that serves REST, WebSocket, component, and Operations API traffic.
+The `http` section in `harper-config.yaml` controls the built-in HTTP server that serves REST, WebSocket, component, and Operations API traffic.
 
 Harper must be restarted for configuration changes to take effect.
 
@@ -32,7 +32,7 @@ The port for HTTPS connections. Requires a valid `tls` section configured with c
 
 ## TLS
 
-TLS is configured in its own top-level `tls` section in `harperdb-config.yaml`, separate from the `http` section. It is shared by the HTTP server (HTTPS), the MQTT broker (secure MQTT), and any TLS socket servers. See [TLS Configuration](./tls) for all options including multi-domain (SNI) certificates and the Operations API override.
+TLS is configured in its own top-level `tls` section in `harper-config.yaml`, separate from the `http` section. It is shared by the HTTP server (HTTPS), the MQTT broker (secure MQTT), and any TLS socket servers. See [TLS Configuration](./tls) for all options including multi-domain (SNI) certificates and the Operations API override.
 
 To enable HTTPS, set `http.securePort` and add a `tls` block:
 

--- a/reference/http/overview.md
+++ b/reference/http/overview.md
@@ -38,7 +38,7 @@ The HTTP server handles multiple protocols on the same port:
 
 ## TLS / HTTPS
 
-HTTPS support is enabled by setting `http.securePort` in `harperdb-config.yaml` and configuring the `tls` section with a certificate and private key. The same `tls` configuration is shared by HTTPS and MQTT secure connections.
+HTTPS support is enabled by setting `http.securePort` in `harper-config.yaml` and configuring the `tls` section with a certificate and private key. The same `tls` configuration is shared by HTTPS and MQTT secure connections.
 
 See [Configuration](./configuration) for TLS options and [Security](../security/overview.md) for certificate management details.
 
@@ -46,7 +46,7 @@ See [Configuration](./configuration) for TLS options and [Security](../security/
 
 <VersionBadge version="v4.5.0" />
 
-HTTP/2 can be enabled with the `http2: true` option in `harperdb-config.yaml`. When enabled, HTTP/2 applies to all API endpoints served on `http.securePort` (HTTP/2 requires TLS).
+HTTP/2 can be enabled with the `http2: true` option in `harper-config.yaml`. When enabled, HTTP/2 applies to all API endpoints served on `http.securePort` (HTTP/2 requires TLS).
 
 ## Compression
 

--- a/reference/http/tls.md
+++ b/reference/http/tls.md
@@ -6,7 +6,7 @@ title: TLS Configuration
 <!-- Source: versioned_docs/version-4.7/deployments/configuration.md (tls section - primary) -->
 <!-- Source: release-notes/v4-tucker/4.2.0.md (confirmed top-level tls section added) -->
 
-Harper uses a top-level `tls` section in `harperdb-config.yaml` to configure Transport Layer Security. This configuration is shared by the HTTP server (HTTPS), the MQTT broker (secure MQTT), and any TLS socket servers created via the [HTTP API](./api#serversocketlistener-options).
+Harper uses a top-level `tls` section in `harper-config.yaml` to configure Transport Layer Security. This configuration is shared by the HTTP server (HTTPS), the MQTT broker (secure MQTT), and any TLS socket servers created via the [HTTP API](./api#serversocketlistener-options).
 
 The `operationsApi` section can optionally define its own `tls` block, which overrides the root `tls` for Operations API traffic only. See the [Operations API Configuration](../configuration/operations.md) for more details.
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -32,7 +32,7 @@ For concept introductions, tutorials, and guides, see the [Learn](/learn) sectio
 | Section                                        | Description                                                   |
 | ---------------------------------------------- | ------------------------------------------------------------- |
 | [CLI](./cli/overview.md)                       | All CLI commands, Operations API commands, and authentication |
-| [Configuration](./configuration/overview.md)   | `harperdb-config.yaml` options and configuration operations   |
+| [Configuration](./configuration/overview.md)   | `harper-config.yaml` options and configuration operations   |
 | [Operations API](./operations-api/overview.md) | Full index of all Operations API operations                   |
 
 ### Features

--- a/reference/index.md
+++ b/reference/index.md
@@ -32,7 +32,7 @@ For concept introductions, tutorials, and guides, see the [Learn](/learn) sectio
 | Section                                        | Description                                                   |
 | ---------------------------------------------- | ------------------------------------------------------------- |
 | [CLI](./cli/overview.md)                       | All CLI commands, Operations API commands, and authentication |
-| [Configuration](./configuration/overview.md)   | `harper-config.yaml` options and configuration operations   |
+| [Configuration](./configuration/overview.md)   | `harper-config.yaml` options and configuration operations     |
 | [Operations API](./operations-api/overview.md) | Full index of all Operations API operations                   |
 
 ### Features

--- a/reference/logging/api.md
+++ b/reference/logging/api.md
@@ -134,11 +134,11 @@ For external components, the thread context is set automatically based on which 
 Fake news (for now)
 ### TypeScript / Module Import
 
-The `logger` global is also exported from the `harperdb` package for better TypeScript support:
+The `logger` global is also exported from the `harper` package for better TypeScript support:
 
 ```typescript
-import { logger } from 'harperdb';
-import type { MainLogger, TaggedLogger } from 'harperdb';
+import { logger } from 'harper';
+import type { MainLogger, TaggedLogger } from 'harper';
 
 logger.info('Component started');
 

--- a/reference/logging/configuration.md
+++ b/reference/logging/configuration.md
@@ -8,7 +8,7 @@ title: Logging Configuration
 <!-- Source: release-notes/v4-tucker/4.2.0.md (confirmed auditAuthEvents.logFailed/logSuccessful added) -->
 <!-- Source: release-notes/v4-tucker/4.6.0.md (confirmed per-component logging, dynamic reload, HTTP logging) -->
 
-The `logging` section in `harperdb-config.yaml` controls standard log output. Many logging settings are applied dynamically without a restart (added in v4.6.0).
+The `logging` section in `harper-config.yaml` controls standard log output. Many logging settings are applied dynamically without a restart (added in v4.6.0).
 
 ## Main Logger
 

--- a/reference/mqtt/configuration.md
+++ b/reference/mqtt/configuration.md
@@ -9,7 +9,7 @@ title: MQTT Configuration
 <!-- Source: release-notes/v4-tucker/4.3.0.md (confirmed mTLS support added) -->
 <!-- Source: release-notes/v4-tucker/4.5.0.md (confirmed default replication port change - note: this is the replication port, not MQTT) -->
 
-The `mqtt` section in `harperdb-config.yaml` controls Harper's built-in MQTT broker. MQTT is enabled by default.
+The `mqtt` section in `harper-config.yaml` controls Harper's built-in MQTT broker. MQTT is enabled by default.
 
 Harper must be restarted for configuration changes to take effect.
 

--- a/reference/operations-api/operations.md
+++ b/reference/operations-api/operations.md
@@ -693,7 +693,7 @@ Detailed documentation: [Configuration Overview](../configuration/overview.md)
 
 ### `set_configuration`
 
-Updates configuration parameters in `harperdb-config.yaml`. A restart (`restart` or `restart_service`) is required for changes to take effect.
+Updates configuration parameters in `harper-config.yaml`. A restart (`restart` or `restart_service`) is required for changes to take effect.
 
 ```json
 {

--- a/reference/replication/overview.md
+++ b/reference/replication/overview.md
@@ -17,7 +17,7 @@ Harper replication uses a peer-to-peer model where every node in your cluster ca
 
 ### Connecting Nodes
 
-To connect nodes to each other, provide hostnames or URLs in the `replication` section of `harperdb-config.yaml`. Each node specifies its own hostname and the routes (other nodes) it should connect to:
+To connect nodes to each other, provide hostnames or URLs in the `replication` section of `harper-config.yaml`. Each node specifies its own hostname and the routes (other nodes) it should connect to:
 
 ```yaml
 replication:
@@ -98,7 +98,7 @@ Ensure the certificate's CN matches the node's hostname.
 There are two ways to configure Harper with your own certificates:
 
 1. Use the `add_certificate` operation to upload them.
-2. Specify certificate paths directly in `harperdb-config.yaml`:
+2. Specify certificate paths directly in `harper-config.yaml`:
 
 ```yaml
 tls:
@@ -149,7 +149,7 @@ Via the operations API:
 }
 ```
 
-Via `harperdb-config.yaml`:
+Via `harper-config.yaml`:
 
 ```yaml
 replication:

--- a/reference/replication/sharding.md
+++ b/reference/replication/sharding.md
@@ -30,7 +30,7 @@ There are two main approaches:
 
 ### Replication Count
 
-The simplest way to limit replication is to configure a replication count. Set `replicateTo` in the `replication` section of `harperdb-config.yaml` to specify how many additional nodes data should be replicated to:
+The simplest way to limit replication is to configure a replication count. Set `replicateTo` in the `replication` section of `harper-config.yaml` to specify how many additional nodes data should be replicated to:
 
 ```yaml
 replication:
@@ -107,7 +107,7 @@ class MyTable extends tables.MyTable {
 
 ### Basic Static Shard Configuration
 
-Assign a node to a numbered shard in `harperdb-config.yaml`:
+Assign a node to a numbered shard in `harper-config.yaml`:
 
 ```yaml
 replication:

--- a/reference/security/certificate-management.md
+++ b/reference/security/certificate-management.md
@@ -23,7 +23,7 @@ These certificates have a valid Common Name (CN), but they are not signed by a r
 
 By default, HTTPS is disabled. HTTP is suitable for local development and trusted private networks. If you are developing on a remote server with requests traversing the Internet, enable HTTPS.
 
-To enable HTTPS, set `http.securePort` in `harperdb-config.yaml` and restart Harper:
+To enable HTTPS, set `http.securePort` in `harper-config.yaml` and restart Harper:
 
 ```yaml
 http:

--- a/reference/security/configuration.md
+++ b/reference/security/configuration.md
@@ -5,7 +5,7 @@ title: Authentication Configuration
 
 <!-- Source: versioned_docs/version-4.7/deployments/configuration.md (authentication section, primary) -->
 
-Harper's authentication system is configured via the top-level `authentication` section of `harperdb-config.yaml`.
+Harper's authentication system is configured via the top-level `authentication` section of `harper-config.yaml`.
 
 ```yaml
 authentication:

--- a/reference/security/jwt-authentication.md
+++ b/reference/security/jwt-authentication.md
@@ -91,7 +91,7 @@ When both tokens have expired, call `create_authentication_tokens` again with yo
 
 ## Token Expiry Configuration
 
-Token timeouts are configurable in `harperdb-config.yaml` under the top-level `authentication` section:
+Token timeouts are configurable in `harper-config.yaml` under the top-level `authentication` section:
 
 ```yaml
 authentication:

--- a/reference/security/mtls-authentication.md
+++ b/reference/security/mtls-authentication.md
@@ -20,7 +20,7 @@ Harper supports Mutual TLS (mTLS) authentication for incoming HTTP connections. 
 
 ## Configuration
 
-mTLS is configured via the `http.mtls` section in `harperdb-config.yaml`.
+mTLS is configured via the `http.mtls` section in `harper-config.yaml`.
 
 **Require mTLS for all connections:**
 

--- a/reference/users-and-roles/configuration.md
+++ b/reference/users-and-roles/configuration.md
@@ -59,7 +59,7 @@ Harper supports two password hashing algorithms, replacing the previous MD5 hash
 - **`sha256`** — Default algorithm. Good security and excellent performance.
 - **`argon2id`** — Highest security. More CPU-intensive; recommended for high-security environments.
 
-Password hashing is configured via the `authentication.hashFunction` key in `harperdb-config.yaml`. See [Security / Configuration](../security/configuration.md#hashfunction) for details.
+Password hashing is configured via the `authentication.hashFunction` key in `harper-config.yaml`. See [Security / Configuration](../security/configuration.md#hashfunction) for details.
 
 ## Related
 


### PR DESCRIPTION
## Changes

Updated all `harperdb` references in `reference/` to use the modern naming:

### `harperdb-config.yaml` → `harper-config.yaml` (21 files)

`configuration/overview.md`, `configuration/options.md`, `components/applications.md`, `http/api.md`, `http/configuration.md`, `http/overview.md`, `http/tls.md`, `logging/configuration.md`, `mqtt/configuration.md`, `operations-api/operations.md`, `replication/overview.md`, `replication/sharding.md`, `security/certificate-management.md`, `security/configuration.md`, `security/jwt-authentication.md`, `security/mtls-authentication.md`, `users-and-roles/configuration.md`, `database/compaction.md`, `database/transaction.md`, `fastify-routes/overview.md`, `index.md`

### `harperdb` CLI/package → `harper` (8 files)

- `components/applications.md` — CLI commands and npm package name
- `components/extension-api.md` — `` `harperdb restart` ``
- `components/plugin-api.md` — `from 'harperdb'` import
- `database/api.md` — `from 'harperdb'` import
- `database/compaction.md` — `copy-db` command and env var CLI invocation
- `configuration/overview.md` — CLI argument usage and standalone invocations
- `http/api.md` — `from 'harperdb'` import, `__harperdb_request_upgraded` → `__harperRequestUpgraded`
- `logging/api.md` — `from 'harperdb'` imports

### Intentionally unchanged

- `cli/overview.md` legacy code block — explicitly documents `harperdb` as the backward-compatible alias
- `@harperdb/` scoped npm package names throughout
- `https://my-harperdb-server:9925/` placeholder hostname in `security/impersonation.md`
- `https://harperdb-component` URL example in `components/applications.md`