### PR TITLE
Document harper-config.yaml backup behavior

### DIFF
--- a/reference/configuration/overview.md
+++ b/reference/configuration/overview.md
@@ -78,6 +78,25 @@ See [Configuration Operations](./operations.md) for the full `set_configuration`
 
 ---
 
+## Configuration File Backups
+
+When `harper-config.yaml` is updated through the [Operations API](#4-operations-api) (`set_configuration`) or by passing CLI arguments / environment variables to Harper at startup, Harper writes a timestamped copy of the previous file to `{rootPath}/backup/` before applying the change.
+
+Backup files are named `<ISO-timestamp>-harper-config.yaml.bak`, for example:
+
+```
+hdb/backup/2026-05-06T14-22-08.123Z-harper-config.yaml.bak
+```
+
+Notes:
+
+- Backups are not produced when you edit `harper-config.yaml` directly — Harper only sees that change on its next start.
+- The `HARPER_DEFAULT_CONFIG` and `HARPER_SET_CONFIG` mechanisms do not produce timestamped backups; their provenance is tracked separately in `{rootPath}/backup/.harper-config-state.json` (see [State Tracking](#state-tracking)).
+- Backups are not rotated. Old `.bak` files accumulate in `{rootPath}/backup/` until you remove them.
+- A failure to write the backup is logged at `error` level and does not block the configuration update.
+
+---
+
 ## Custom Config File Path
 
 To specify a custom config file location at install time, use the `HDB_CONFIG` variable:


### PR DESCRIPTION
## Summary

- Adds a **Configuration File Backups** section to `reference/configuration/overview.md` describing when Harper writes timestamped copies of `harper-config.yaml` to `{rootPath}/backup/`.
- Currently the only mention of this behavior anywhere is a single line in `harper/static/README.md` (the default install landing page), which means it doesn't surface in doc-site search.
- Section covers: trigger paths (operations API `set_configuration` and CLI/env-var startup args), file location and naming convention (`<ISO-timestamp>-harper-config.yaml.bak`), the carve-out that direct YAML edits and `HARPER_SET_CONFIG` / `HARPER_DEFAULT_CONFIG` do not produce timestamped backups, no rotation, and silent-on-failure behavior.

Cross-links to the existing **State Tracking** section so readers see how the same `backup/` folder is also used by the env-var configuration mechanism.

## Test plan

- [ ] Render `reference/configuration/overview.md` locally and confirm the new section appears between **Setting Configuration Values** and **Custom Config File Path**.
- [ ] Verify the in-page anchor link to `#state-tracking` resolves.
- [ ] Search the rendered docs for "backup" and confirm the new section appears in results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)