### PR TITLE
document operationsApi.componentFile.maxSize

### DIFF
--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -104,6 +104,7 @@ operationsApi:
     privateKey: ~/hdb/keys/privateKey.pem
 ```
 
+- `componentFile.maxSize` — Maximum file size in bytes returned by `get_component_file`. Requests for files larger than this limit are rejected with HTTP 413. _Default_: `5242880` (5 MB)
 - `network.cors` / `network.corsAccessList` — CORS settings
 - `network.domainSocket` — Unix socket path for CLI communication; _Default_: `<rootPath>/hdb/operations-server`
 - `network.headersTimeout` / `network.keepAliveTimeout` / `network.timeout` — Timeout settings (ms)


### PR DESCRIPTION
Documents the new `operationsApi.componentFile.maxSize` configuration option added in HarperFast/harper#710.

Adds one bullet to the `operationsApi` section of the Configuration Options reference, covering the default (5 MB), the unit (bytes), and the behaviour on violation (HTTP 413).

Generated by Claude Sonnet 4.6.