### PR TITLE
chore: clean up build warnings

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -244,6 +244,12 @@ const config: Config = {
 					// conversion sees clean structure. See the script header
 					// for details on what gets transformed.
 					beforeDefaultRehypePlugins: [require('./scripts/rehype-docusaurus-to-llms.mjs').default],
+					// Explicit exclusions for routes that are not real content.
+					// /reference is a client-side redirect React component
+					// (src/pages/reference/index.tsx) that returns null; without
+					// this entry the plugin tries to process its empty HTML
+					// shell and emits a warning.
+					excludeRoutes: ['/reference'],
 				},
 			},
 		],

--- a/reference/components/javascript-environment.md
+++ b/reference/components/javascript-environment.md
@@ -46,7 +46,7 @@ An object containing all databases defined in Harper. Each database is an object
 
 See [Database API](../database/api.md) for full reference.
 
-### `transaction(fn)`
+### `transaction(fn)` {#transaction}
 
 Executes a function inside a database transaction. Changes made within the function are committed atomically, or rolled back if an error is thrown.
 


### PR DESCRIPTION
## What and why

Two unrelated warnings have been firing during every docs build since Phase 1 (#497) landed. Both are now fixed. A third "Excluded N routes by current config" warning remains but is just accurate accounting of intentional exclusions — not noise we need to silence.

### Fix 1: `/reference` route processing failure

`src/pages/reference/index.tsx` is a client-side React redirect component that returns `null` — its rendered HTML is an empty Docusaurus shell with no extractable content. The llms-txt plugin was attempting to process it and emitting:

```
[WARNING] [docusaurus-plugin-llms-txt] Route Error: Failed to process route "/reference":
Failed to convert HTML to Markdown: HTML to Markdown conversion resulted in empty content
for "reference.html". This usually means your contentSelectors didn't match any elements...
```

**Fix:** add `/reference` to the plugin's `excludeRoutes` config. This is not a content page; it's a routing redirect that should never be considered for the flat-markdown export.

### Fix 2: Broken anchor in resource-api.md

`reference/resources/resource-api.md` (line 799) linked to `../components/javascript-environment.md#transaction`, but the heading `` ### `transaction(fn)` `` in that target file gets the auto-generated anchor `transactionfn` (parens stripped, dash dropped). The link wanted the semantic name `transaction`, not the auto-id.

The Docusaurus build was complaining:

```
[WARNING] Docusaurus found broken anchors!
- Broken anchor on source page path = /reference/v5/resources/resource-api:
   -> linking to /reference/v5/components/javascript-environment#transaction
```

**Fix:** add an explicit `{#transaction}` anchor to the heading in `javascript-environment.md`. This gives the link a stable, human-meaningful target that survives heading-text changes and matches the original author intent. Docusaurus 3.x supports the `{#id}` syntax natively.

## Verification

- Rebuild produces the same 371 documents across all four docs plugin instances (`learn: 10`, `reference: 137`, `fabric: 10`, `release-notes: 211`)
- Both targeted warnings are gone
- `grep 'id="[^"]*transaction[^"]*"' build/reference/v5/components/javascript-environment.html` now returns `id="transaction"` directly on the heading

## Remaining warning (intentional, not fixed)

```
[WARNING] [docusaurus-plugin-llms-txt] WARNING: Excluded 2 routes by current config
```

This is the plugin reporting that two routes were filtered:
- The home page `/` — a content-pages route, excluded by default via `includePages: false`
- `/reference` — our new explicit exclusion

Both are intentional. Keeping this warning visible is useful signal — it lets us notice if we accidentally exclude more routes in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)