### PR TITLE
feat: dispatch docs-updated to skills repo after deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -123,27 +123,32 @@ jobs:
   # Notify the skills repo that docs changed, so it can regenerate its
   # docs-driven rules against the just-deployed content. See the
   # generate.yaml workflow in HarperFast/skills (Phase 2 of the
-  # docs-driven-skills plan). Requires SKILLS_DISPATCH_TOKEN — a PAT or
-  # App token with contents:write on HarperFast/skills (the default
-  # GITHUB_TOKEN is scoped to this repo only and cannot dispatch across
-  # repos). If the secret is absent, the step is skipped (the skills repo
-  # also runs a weekly safety-net cron).
+  # docs-driven-skills plan).
+  #
+  # Authenticates as the org-owned "harper-skills-sync" GitHub App, minting
+  # a token scoped to HarperFast/skills (the default GITHUB_TOKEN is scoped
+  # to this repo only and cannot dispatch cross-repo). The App must be
+  # installed on the skills repo; this repo holds its SKILLS_SYNC_APP_ID /
+  # SKILLS_SYNC_APP_PRIVATE_KEY secrets. If the App is ever removed, the
+  # skills repo's weekly cron is the safety net.
   notify-skills:
     needs: deploy
     name: Notify skills repo
     runs-on: ubuntu-latest
     steps:
+      - name: Mint app token for skills
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SKILLS_SYNC_APP_ID }}
+          private-key: ${{ secrets.SKILLS_SYNC_APP_PRIVATE_KEY }}
+          owner: HarperFast
+          repositories: skills
+
       - name: Dispatch docs-updated to HarperFast/skills
-        # secrets can't be used in an `if:` expression, so guard inside the
-        # script: if the token is absent, skip cleanly (the skills repo's
-        # weekly cron is the safety net).
         env:
-          GH_TOKEN: ${{ secrets.SKILLS_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "SKILLS_DISPATCH_TOKEN not set — skipping dispatch (skills repo cron will pick up docs changes)."
-            exit 0
-          fi
           gh api repos/HarperFast/skills/dispatches \
             -f event_type=docs-updated \
             -F client_payload[sha]=${{ github.sha }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -119,3 +119,32 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Notify the skills repo that docs changed, so it can regenerate its
+  # docs-driven rules against the just-deployed content. See the
+  # generate.yaml workflow in HarperFast/skills (Phase 2 of the
+  # docs-driven-skills plan). Requires SKILLS_DISPATCH_TOKEN — a PAT or
+  # App token with contents:write on HarperFast/skills (the default
+  # GITHUB_TOKEN is scoped to this repo only and cannot dispatch across
+  # repos). If the secret is absent, the step is skipped (the skills repo
+  # also runs a weekly safety-net cron).
+  notify-skills:
+    needs: deploy
+    name: Notify skills repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch docs-updated to HarperFast/skills
+        # secrets can't be used in an `if:` expression, so guard inside the
+        # script: if the token is absent, skip cleanly (the skills repo's
+        # weekly cron is the safety net).
+        env:
+          GH_TOKEN: ${{ secrets.SKILLS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "SKILLS_DISPATCH_TOKEN not set — skipping dispatch (skills repo cron will pick up docs changes)."
+            exit 0
+          fi
+          gh api repos/HarperFast/skills/dispatches \
+            -f event_type=docs-updated \
+            -F client_payload[sha]=${{ github.sha }}
+

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -152,4 +152,3 @@ jobs:
           gh api repos/HarperFast/skills/dispatches \
             -f event_type=docs-updated \
             -F client_payload[sha]=${{ github.sha }}
-


### PR DESCRIPTION
## Companion to the docs-driven skills work (Phase 2b)

Adds a `notify-skills` job to the deploy workflow that fires a `repository_dispatch` (`event_type: docs-updated`, with the docs commit SHA) to `HarperFast/skills` after a successful Pages deploy. The skills repo's `generate.yaml` workflow listens for it and regenerates its docs-driven rules against the just-deployed content.

This is the trigger side of the docs → skills sync. The consuming workflow lives in `HarperFast/skills` (companion PR there).

## How it works

```yaml
notify-skills:
  needs: deploy
  steps:
    - name: Dispatch docs-updated to HarperFast/skills
      env:
        GH_TOKEN: ${{ secrets.SKILLS_DISPATCH_TOKEN }}
      run: |
        if [ -z "$GH_TOKEN" ]; then
          echo "...skipping dispatch (skills repo cron will pick up docs changes)."
          exit 0
        fi
        gh api repos/HarperFast/skills/dispatches \
          -f event_type=docs-updated \
          -F client_payload[sha]=${{ github.sha }}
```

## Requires a secret

`SKILLS_DISPATCH_TOKEN` — a PAT or App token with `contents:write` on `HarperFast/skills`. The default `GITHUB_TOKEN` is scoped to this repo only and cannot dispatch cross-repo.

**Graceful degradation:** if the secret is absent, the step skips cleanly (it does **not** fail the deploy). The skills repo runs a weekly safety-net cron, so a missing token degrades to "docs → skills synced weekly" rather than breaking anything.

## Notes

- `notify-skills` `needs: deploy`, so it only fires after a successful Pages deploy.
- `secrets` can't be referenced in an `if:` expression, so the token presence is guarded inside the script (standard GitHub Actions pattern).
- Zero impact on the existing build/deploy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)