### PR TITLE
docs: clarify loadEnv files option is required

### DIFF
--- a/reference/environment-variables/overview.md
+++ b/reference/environment-variables/overview.md
@@ -13,6 +13,13 @@ Harper supports loading environment variables in Harper applications `process.en
 If you are looking for information on how to configure your Harper installation using environment variables, see [Configuration](../configuration/overview.md) section for more information.
 :::
 
+## Configuration
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `files` | `string \| string[]` | **Yes** | Path(s) or glob pattern(s) to the env file(s) to load. |
+| `override` | `boolean` | No | If `true`, loaded values override existing environment variables. Defaults to `false`. |
+
 ## Basic Usage
 
 ```yaml

--- a/reference/environment-variables/overview.md
+++ b/reference/environment-variables/overview.md
@@ -15,10 +15,10 @@ If you are looking for information on how to configure your Harper installation 
 
 ## Configuration
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `files` | `string \| string[]` | **Yes** | Path(s) or glob pattern(s) to the env file(s) to load. |
-| `override` | `boolean` | No | If `true`, loaded values override existing environment variables. Defaults to `false`. |
+| Option     | Type                 | Required | Description                                                                            |
+| ---------- | -------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `files`    | `string \| string[]` | **Yes**  | Path(s) or glob pattern(s) to the env file(s) to load.                                 |
+| `override` | `boolean`            | No       | If `true`, loaded values override existing environment variables. Defaults to `false`. |
 
 ## Basic Usage
 

--- a/reference_versioned_docs/version-v4/environment-variables/overview.md
+++ b/reference_versioned_docs/version-v4/environment-variables/overview.md
@@ -13,6 +13,13 @@ Harper supports loading environment variables in Harper applications `process.en
 If you are looking for information on how to configure your Harper installation using environment variables, see [Configuration](../configuration/overview.md) section for more information.
 :::
 
+## Configuration
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `files` | `string \| string[]` | **Yes** | Path(s) or glob pattern(s) to the env file(s) to load. |
+| `override` | `boolean` | No | If `true`, loaded values override existing environment variables. Defaults to `false`. |
+
 ## Basic Usage
 
 ```yaml

--- a/reference_versioned_docs/version-v4/environment-variables/overview.md
+++ b/reference_versioned_docs/version-v4/environment-variables/overview.md
@@ -15,10 +15,10 @@ If you are looking for information on how to configure your Harper installation 
 
 ## Configuration
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `files` | `string \| string[]` | **Yes** | Path(s) or glob pattern(s) to the env file(s) to load. |
-| `override` | `boolean` | No | If `true`, loaded values override existing environment variables. Defaults to `false`. |
+| Option     | Type                 | Required | Description                                                                            |
+| ---------- | -------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `files`    | `string \| string[]` | **Yes**  | Path(s) or glob pattern(s) to the env file(s) to load.                                 |
+| `override` | `boolean`            | No       | If `true`, loaded values override existing environment variables. Defaults to `false`. |
 
 ## Basic Usage
 


### PR DESCRIPTION
## Summary

- Adds a Configuration table to the `loadEnv` reference page (current and v4 versioned docs) that explicitly marks `files` as a **required** option
- The table also documents the optional `override` flag in one place

## Motivation

The previous docs only showed `files` in examples without indicating it was mandatory, making it easy to incorrectly use `loadEnv: true`.

## Test plan

- [ ] Verify the Configuration table renders correctly on both the current and v4 versioned environment-variables pages
- [ ] Confirm `files` is visually marked as required

🤖 Generated with [Claude Code](https://claude.com/claude-code)