### PR TITLE
docs: add describe_database verification step to getting-started guide

### DIFF
--- a/learn/getting-started/create-your-first-application.mdx
+++ b/learn/getting-started/create-your-first-application.mdx
@@ -157,6 +157,24 @@ Click "Restart Cluster" to apply the new file changes.
 
 </Tabs>
 
+## Verifying the Table Was Created
+
+Once Harper has started, confirm your `Dog` table was picked up from `schema.graphql` by running:
+
+```bash
+harper describe_data
+```
+
+You should see output like:
+
+```
+Connecting to local Harper instance
+Schema: data
+  Dog  [id*, name, breed, age]
+```
+
+The asterisk marks the primary key. If the table is missing, double-check that `config.yaml` references the correct schema file and that Harper restarted after the file was saved.
+
 ## Enabling the REST API
 
 Navigate back to the `schema.graphql` file and add `@export` directive to the table schema:

--- a/learn/getting-started/create-your-first-application.mdx
+++ b/learn/getting-started/create-your-first-application.mdx
@@ -162,18 +162,30 @@ Click "Restart Cluster" to apply the new file changes.
 Once Harper has started, confirm your `Dog` table was picked up from `schema.graphql` by running:
 
 ```bash
-harper describe_data
+harper describe_database database=data
 ```
 
-You should see output like:
+You should see YAML output describing the `Dog` table and its attributes:
 
-```
-Connecting to local Harper instance
-Schema: data
-  Dog  [id*, name, breed, age]
+```yaml
+Dog:
+  schema: data
+  name: Dog
+  primary_key: id
+  attributes:
+    - attribute: id
+      type: ID
+      is_primary_key: true
+    - attribute: name
+      type: String
+    - attribute: breed
+      type: String
+    - attribute: age
+      type: Int
+  ...
 ```
 
-The asterisk marks the primary key. If the table is missing, double-check that `config.yaml` references the correct schema file and that Harper restarted after the file was saved.
+If the table is missing, double-check that `config.yaml` references the correct schema file and that Harper restarted after the file was saved.
 
 ## Enabling the REST API
 


### PR DESCRIPTION
## Summary

Adds a "Verifying the Table Was Created" section between "Running the Application" and "Enabling the REST API" in the getting-started guide.

**The gap it fills:** after running `harper dev .`, new users have no indication that their schema was processed and the `Dog` table was created. Without a verification step they jump straight to enabling the REST API with no confidence the table actually exists.

The new section uses the existing `harper describe_database database=data` CLI passthrough (no new command needed) and shows the expected YAML output so users know what success looks like.

## Test plan

- [ ] Follow the guide through "Running the Application", run `harper describe_database database=data`, confirm output matches the docs example
- [ ] Verify the section renders correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)