### PR TITLE
fix(caching-guide): correct jokeAPI.get() signature in complete example

### DIFF
--- a/learn/developers/caching-with-harper.mdx
+++ b/learn/developers/caching-with-harper.mdx
@@ -335,8 +335,7 @@ Here is the complete `resources.js` for this guide:
 // resources.js
 
 const jokeAPI = {
-	async get() {
-		const id = this.getId();
+	async get(id) {
 		const response = await fetch(`https://official-joke-api.appspot.com/jokes/${id}`);
 		return response.json();
 	},


### PR DESCRIPTION
## Summary

- The \"Putting It All Together\" example used `async get()` with `this.getId()` inside the body, which throws `TypeError: this.getId is not a function` at runtime
- The correct signature is `async get(id)` — `id` is passed as a parameter by Harper's `sourcedFrom` machinery, not via a method on `this`
- The earlier \"Wrapping an External Data Source\" section already used the correct form; this fix makes the final example consistent with it and with the working `caching-guide-example` repo

## Test plan

- [ ] Follow the caching-with-harper guide end-to-end: `GET /JokeCache/1` returns a joke (not a 500)
- [ ] Verify the \"Putting It All Together\" snippet matches the `caching-guide-example` `main` branch

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — fix verified by running the full caching guide locally (all four scenarios: miss, cached, 304, no-cache, invalidate).