### PR TITLE
docs: add missing 4.5.41/42 and 4.7.30–33 release notes

### DIFF
--- a/release-notes/v4-tucker/4.5.41.md
+++ b/release-notes/v4-tucker/4.5.41.md
@@ -1,0 +1,9 @@
+---
+title: 4.5.41
+---
+
+### HarperDB 4.5.41
+
+4/19/2026
+
+- Fix x509_cert variable name in certificate handling

--- a/release-notes/v4-tucker/4.5.42.md
+++ b/release-notes/v4-tucker/4.5.42.md
@@ -1,0 +1,9 @@
+---
+title: 4.5.42
+---
+
+### HarperDB 4.5.42
+
+6/1/2026
+
+- Upgrade LMDB to 3.5.5 to fix orphaned read snapshot not being released when only renewing cursors remain

--- a/release-notes/v4-tucker/4.7.30.md
+++ b/release-notes/v4-tucker/4.7.30.md
@@ -1,0 +1,10 @@
+---
+title: 4.7.30
+---
+
+### HarperDB 4.7.30
+
+5/20/2026
+
+- Force structures reload on first audit record per replication subscription
+- Backported Harper CA cert for CSR and nuanced TLS scoring

--- a/release-notes/v4-tucker/4.7.31.md
+++ b/release-notes/v4-tucker/4.7.31.md
@@ -1,0 +1,9 @@
+---
+title: 4.7.31
+---
+
+### HarperDB 4.7.31
+
+5/20/2026
+
+- Added libatomic1 dependency for pnpm-based installs

--- a/release-notes/v4-tucker/4.7.32.md
+++ b/release-notes/v4-tucker/4.7.32.md
@@ -1,0 +1,9 @@
+---
+title: 4.7.32
+---
+
+### HarperDB 4.7.32
+
+5/20/2026
+
+- Fix replication table copy audit entries to include expiresAt

--- a/release-notes/v4-tucker/4.7.33.md
+++ b/release-notes/v4-tucker/4.7.33.md
@@ -1,0 +1,9 @@
+---
+title: 4.7.33
+---
+
+### HarperDB 4.7.33
+
+6/1/2026
+
+- Upgrade LMDB to 3.5.5 to fix orphaned read snapshot not being released when only renewing cursors remain


### PR DESCRIPTION
## Summary

- Add 4.5.41 and 4.5.42 release notes (were missing from v4-tucker)
- Add 4.7.30, 4.7.31, 4.7.32, and 4.7.33 release notes (were missing from v4-tucker)

Notable changes covered:
- 4.7.30: Force structures reload on first replication audit record; backport CA cert/TLS scoring
- 4.7.31: libatomic1 dep for pnpm installs
- 4.7.32: Fix replication table copy audit entries to include expiresAt
- 4.7.33 / 4.5.42: LMDB 3.5.5 — fixes orphaned read snapshot not released when only renewing cursors remain
- 4.5.41: Fix x509_cert variable name

🤖 Generated with [Claude Code](https://claude.com/claude-code)