### PR TITLE
docs: add positioning summary and harper.fast cross-reference to llms.txt

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -232,6 +232,23 @@ const config: Config = {
 		[
 			'@signalwire/docusaurus-plugin-llms-txt',
 			{
+				// Positioning blockquote rendered under the `# Harper Docs`
+				// header of llms.txt. Mirrors the framing on harper.fast so a
+				// crawler that only fetches the docs file (more likely for
+				// technical queries) still gets the product context.
+				siteDescription:
+					'Harper is a single in-process runtime that unifies your database, application logic, APIs, caching, real-time messaging, and agent loops, replicated across a multi-region data application fabric. This site is the official technical documentation: guides, API and configuration reference, and Fabric operations.',
+				// Cross-reference to the marketing site so any agent that lands
+				// on the docs llms.txt can discover the companion file at
+				// harper.fast/llms.txt (and vice-versa).
+				optionalLinks: [
+					{
+						title: 'Harper product overview (harper.fast)',
+						url: 'https://www.harper.fast',
+						description:
+							'Marketing site with positioning and use cases; companion llms.txt at https://www.harper.fast/llms.txt',
+					},
+				],
 				content: {
 					// Defaults: enableMarkdownFiles: true, includeDocs: true,
 					// includeVersionedDocs: true. All four docs plugin instances


### PR DESCRIPTION
## What

Two small additions to the `@signalwire/docusaurus-plugin-llms-txt` config so the generated `llms.txt` is better framed for crawlers/agents:

1. **`siteDescription`** — adds a positioning blockquote under the `# Harper Docs` header. Previously the file jumped straight to `## search` with no context.
2. **`optionalLinks`** — a cross-reference to `harper.fast` and its companion `llms.txt`, so an agent that lands on either file can discover the other.

## Why

In an internal review of our `llms.txt` files, two gaps were flagged: the docs file had no top-level positioning paragraph (most well-crafted `llms.txt` files — Anthropic's, Cloudflare's, LangChain's — open with one), and the docs/marketing files didn't reference each other. A crawler is more likely to fetch the docs file for technical queries, so it should still carry the product framing on its own.

## Before / after (top of `build/llms.txt`)

**Before**
```
# Harper Docs


## search
```

**After**
```
# Harper Docs

> Harper is a single in-process runtime that unifies your database, application logic, APIs, caching, real-time messaging, and agent loops, replicated across a multi-region data application fabric. This site is the official technical documentation: guides, API and configuration reference, and Fabric operations.


## fabric
```

…and in the Optional links section:
```
- [Harper product overview (harper.fast)](https://www.harper.fast): Marketing site with positioning and use cases; companion llms.txt at https://www.harper.fast/llms.txt
```

## Testing

`npm run build` succeeds (372 documents processed) and `build/llms.txt` contains the blockquote and the cross-reference link as shown above.

Refs HarperFast/ospo#24, HarperFast/ospo#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)