### PR TITLE
docs: require formatting for every contribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ Review `README.md` and `CONTRIBUTING.md` for all relevant repository information
 
 - TypeScript (config files and scripts), MDX/Markdown (content).
 - Prettier is configured via `@harperdb/code-guidelines/prettier` (see `package.json`).
-- Format command: `npm run format:write`. Run this after editing any `.ts`, `.md`, or `.mdx` files.
+- **Required before every commit/PR:** run `npm run format:write`, then confirm `npm run format:check` is clean. This is a hard gate, not advisory — CI fails any unformatted PR (see [CI](#ci)).
+- Formatting applies to **every file in the repo**, not just content. Prettier runs against the whole tree (`prettier .`) — `.ts`, `.md`, `.mdx`, `.json`, and files under `plans/`, `scripts/`, etc. Do not assume a directory is exempt because it is not user-facing docs.
 - The lint script is a no-op (`echo 0`); do not expect `npm run lint` to catch issues.
 
 ## Content Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,20 @@ npm run format:write
 
 5. Push changes to a branch and create a pull request
 
+## Formatting
+
+**Every contribution must be formatted before it is committed.** This applies to _all_ files in the repository — content (`.md`/`.mdx`), TypeScript, config, and anything else under `plans/`, `scripts/`, etc. — not just docs content.
+
+```bash
+# Format everything (run before committing):
+npm run format:write
+
+# Check formatting without writing (what CI runs):
+npm run format:check
+```
+
+CI runs `npm run format:check` on every pull request and will fail if anything is unformatted. If CI fails on formatting, run `npm run format:write` locally and commit the result. Prettier is configured via `@harperdb/code-guidelines/prettier` (see `package.json`).
+
 ## Site Organization
 
 This site is powered by Docusaurus. The documentation is split into four distinct sections, each serving a different purpose and configured as its own Docusaurus plugin instance.


### PR DESCRIPTION
## Summary

Formatting was already documented, but as advisory guidance rather than a hard gate — which is how unformatted files (the `plans/` scaffolding in #520) slipped through. This tightens the contribution docs so future contributions, including agentic ones, treat formatting as a non-negotiable pre-PR step.

- **AGENTS.md** — make `npm run format:write` / `format:check` a hard pre-commit/PR gate (not advisory), and clarify it applies to **every file in the repo**, not just docs content (so generated files under `plans/`, `scripts/`, etc. aren't missed).
- **CONTRIBUTING.md** — add a dedicated **Formatting** section stating every contribution must be formatted and that CI enforces `format:check`.
- **README.md** — left unchanged; it delegates to CONTRIBUTING.md and duplicating specifics would just risk drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)