### PR TITLE
docs(mcp): document Origin validation / CORS secure defaults

### DIFF
--- a/reference/mcp/configuration.md
+++ b/reference/mcp/configuration.md
@@ -134,14 +134,16 @@ When `true`, Harper accepts client-issued `DELETE /mcp` requests that explicitly
 
 The MCP endpoint validates the request `Origin` header to defend against DNS-rebinding attacks (a requirement of the MCP Streamable HTTP transport). Validation reuses each profile's existing CORS configuration rather than introducing a separate MCP setting:
 
-- When CORS is **disabled** (the default), any `Origin` is accepted. This is appropriate for localhost-only or non-browser clients, where no DNS-rebinding vector exists.
-- When CORS is **enabled** with an allow-list, a request whose `Origin` is not in the list is rejected with `403 Forbidden`. A `*` entry allows any origin.
+- When CORS is **disabled** — or enabled with a `*` (wildcard) allow-list — any `Origin` is accepted. This is appropriate for localhost-only or non-browser clients, where no DNS-rebinding vector exists.
+- When CORS is **enabled** with an explicit allow-list, a request whose `Origin` is not in the list is rejected with `403 Forbidden`.
 - A request with no `Origin` header at all (for example `curl` or server-to-server traffic) is always accepted — DNS rebinding only applies to browser-initiated requests.
 
-**Secure default:** any deployment that exposes the MCP endpoint to browsers beyond loopback should enable CORS with an explicit allow-list — that is what activates Origin-based DNS-rebinding protection.
+**Secure default:** any deployment that exposes the MCP endpoint to browsers beyond loopback should enable CORS with an explicit (non-`*`) allow-list — that is what activates Origin-based DNS-rebinding protection.
 
-- Application profile (HTTP port): `http.cors` + `http.corsAccessList`.
-- Operations profile (operations port): `operationsApi.network.cors` + `operationsApi.network.corsAccessList`.
+The two profiles ship with **different CORS defaults**, but both accept any `Origin` out of the box:
+
+- Application profile (HTTP port): `http.cors` + `http.corsAccessList`. Default: CORS **disabled**, so any `Origin` is accepted.
+- Operations profile (operations port): `operationsApi.network.cors` + `operationsApi.network.corsAccessList`. Default: CORS **enabled with a `*` allow-list**, so any `Origin` is still accepted until you replace `*` with explicit origins.
 
 ## Example
 

--- a/reference/mcp/configuration.md
+++ b/reference/mcp/configuration.md
@@ -130,6 +130,19 @@ Default: `false`
 
 When `true`, Harper accepts client-issued `DELETE /mcp` requests that explicitly terminate a session. When `false` (the default), `DELETE` returns 405 with an `Allow` header — sessions only end via idle eviction or explicit server-side cleanup.
 
+## Security: Origin validation
+
+The MCP endpoint validates the request `Origin` header to defend against DNS-rebinding attacks (a requirement of the MCP Streamable HTTP transport). Validation reuses each profile's existing CORS configuration rather than introducing a separate MCP setting:
+
+- When CORS is **disabled** (the default), any `Origin` is accepted. This is appropriate for localhost-only or non-browser clients, where no DNS-rebinding vector exists.
+- When CORS is **enabled** with an allow-list, a request whose `Origin` is not in the list is rejected with `403 Forbidden`. A `*` entry allows any origin.
+- A request with no `Origin` header at all (for example `curl` or server-to-server traffic) is always accepted — DNS rebinding only applies to browser-initiated requests.
+
+**Secure default:** any deployment that exposes the MCP endpoint to browsers beyond loopback should enable CORS with an explicit allow-list — that is what activates Origin-based DNS-rebinding protection.
+
+- Application profile (HTTP port): `http.cors` + `http.corsAccessList`.
+- Operations profile (operations port): `operationsApi.network.cors` + `operationsApi.network.corsAccessList`.
+
 ## Example
 
 A common deployment pattern that locks down the operations profile to a small explicit set, enables MCP DELETE for graceful client logout, and raises per-tool throughput for the application profile:


### PR DESCRIPTION
Companion to HarperFast/harper#1320 (issue HarperFast/harper#1317, S4).

Adds a **Security: Origin validation** section to `reference/mcp/configuration.md` documenting that the MCP endpoint validates the `Origin` header (DNS-rebinding defense) via each profile's existing CORS config, and that any deployment exposing MCP to browsers beyond loopback should enable an explicit CORS allow-list to activate that protection.

No new config surface — the behavior already ships; this fills a documentation gap surfaced while fixing #1317. `format:check` is clean.

Generated by an LLM (Claude Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)