### PR TITLE
docs(mcp): resource subscriptions + stream resumability

### DIFF
--- a/reference/mcp/overview.md
+++ b/reference/mcp/overview.md
@@ -13,6 +13,8 @@ Harper implements the [Model Context Protocol](https://modelcontextprotocol.io) 
 - **Tool discovery and invocation.** LLM hosts get a typed list of operations they can call (`tools/list`) and a uniform JSON-RPC invocation envelope (`tools/call`). Per-tool input schemas come from Harper's operation catalog (operations profile) or from your `Table.attributes` and exported `Resource` classes (application profile).
 - **Resource exposure.** Synthetic `harper://` URIs surface metadata (server info, OpenAPI document, table schemas, operations catalog), and `https://` URIs mirror your application's REST surface so hosts can resolve real REST endpoints in-process.
 - **Server-push notifications.** `notifications/tools/list_changed` and `notifications/resources/list_changed` fire over an open Server-Sent Events channel when role mutations or schema changes alter what a session can see.
+- **Resource subscriptions.** <VersionBadge version="v5.1.10" /> Subscribe to a row-backed application resource with `resources/subscribe` and receive a `notifications/resources/updated` push whenever that record (or table) changes, driven by Harper's audit-log change feed. See [Resource Subscriptions](./subscriptions.md).
+- **Resumable notification streams.** <VersionBadge version="v5.1.10" /> A dropped GET-SSE connection can reconnect with a `Last-Event-ID` header and replay the notifications it missed from a bounded per-session buffer, so a brief network blip doesn't lose `list_changed` / `resources/updated` events. See [Resource Subscriptions](./subscriptions.md#resuming-a-dropped-stream).
 - **Per-session bookkeeping.** Sessions persist for the configured idle window; `Mcp-Session-Id` ties JSON-RPC requests, GET-SSE notifications, and the optional DELETE-session cleanup together.
 - **Built-in auth and RBAC.** Harper's existing Basic, JWT, and mTLS authentication paths run unchanged on the MCP endpoint. Tool and resource visibility is filtered through your role's `permission` block (`super_user`, `structure_user`, per-operation, per-table, per-attribute).
 - **Audit + rate limits.** Every `tools/call` writes to Harper's audit log (with credential redaction); per-session and per-tool token-bucket rate limits prevent a runaway agent from overwhelming a Harper worker.
@@ -62,8 +64,6 @@ See [MCP Tools and Resources](./tools-and-resources.md) for the full generation 
 The following items are explicitly deferred to a follow-on release:
 
 - OAuth 2.1 PRM (Protected Resource Metadata) authorization.
-- `resources/subscribe` (per-resource change subscriptions; `list_changed` is supported).
-- `Last-Event-ID` resumability for the GET-SSE channel.
 - Cross-worker session sharing (each MCP session is bound to the worker that accepted the GET stream).
-- TypeScript type reflection into JSON Schema for custom `mcpTools` entries (schemas are hand-authored in v1).
+- TypeScript type reflection into JSON Schema for custom `mcpTools` entries (schemas are hand-authored).
 - Global REST/operations rate limiting — only per-session/per-tool limits apply on the MCP surface.

--- a/reference/mcp/subscriptions.md
+++ b/reference/mcp/subscriptions.md
@@ -107,7 +107,7 @@ Send `resources/unsubscribe` with the same URI:
 }
 ```
 
-- `params.uri` is required (`-32602` otherwise).
+- `params.uri` is required and must be a string — otherwise `-32602` (`resources/unsubscribe requires params.uri`).
 - Unsubscribing a URI that was never subscribed is a no-op and still returns `{}`.
 
 Subscriptions are also torn down automatically when the session's GET-SSE stream closes — via explicit `DELETE /mcp`, idle-timeout eviction from `system.mcp_session`, a dropped TCP connection, or an idle-prune sweep.
@@ -130,7 +130,7 @@ Harper replays every buffered frame with a higher id (exclusive) before live fra
 
 Caveats, all best-effort by design:
 
-- **Buffer bound.** Only the last 100 frames are retained; a client that was disconnected long enough to miss more than 100 frames will not get the older ones. A non-numeric `Last-Event-ID` replays whatever is in the buffer.
+- **Buffer bound.** Only the last 100 frames are retained; a client that was disconnected long enough to miss more than 100 frames will not get the older ones. A non-numeric `Last-Event-ID` replays the entire buffer.
 - **Per-worker.** The replay buffer and event-id sequence live on the worker that served the original stream. If the reconnecting `GET` lands on a different worker (one that never held the prior stream), its buffer is empty and there is nothing to replay. This is the same per-worker binding that scopes sessions and subscriptions.
 
 ## Not yet supported

--- a/reference/mcp/subscriptions.md
+++ b/reference/mcp/subscriptions.md
@@ -1,0 +1,138 @@
+---
+title: MCP Resource Subscriptions
+---
+
+# MCP Resource Subscriptions
+
+<VersionBadge version="v5.1.10" />
+
+Beyond the `notifications/*/list_changed` events that tell a client _what tools and resources exist_, Harper can push a notification whenever the _contents_ of a specific application resource change. A client subscribes to a resource URI with `resources/subscribe`; Harper watches that record (or table) through its audit-log change feed and emits `notifications/resources/updated` on every commit.
+
+This page covers `resources/subscribe` / `resources/unsubscribe`, the `notifications/resources/updated` push, which URIs are subscribable, and `Last-Event-ID` stream resumability. The `list_changed` events themselves are documented in [MCP Tools and Resources](./tools-and-resources.md#notificationslist_changed).
+
+Harper advertises the capability on `initialize`:
+
+```json
+{
+	"capabilities": {
+		"tools": { "listChanged": true },
+		"resources": { "listChanged": true, "subscribe": true },
+		"prompts": { "listChanged": true },
+		"completions": {},
+		"logging": {}
+	}
+}
+```
+
+## Prerequisites
+
+A subscription delivers its updates over the session's GET-SSE channel, so the client **must open `GET /mcp` before calling `resources/subscribe`**. Subscribing without a live stream returns `-32602`:
+
+```json
+{ "error": { "code": -32602, "message": "open the GET SSE stream before subscribing to resources" } }
+```
+
+The open stream is also the subscription's lifecycle boundary: when it closes (by any of the paths in [Unsubscribing](#unsubscribing)), the subscription's underlying change iterator is released. This is why Harper rejects a stream-less subscribe rather than letting the iterator leak with nowhere to deliver.
+
+## Subscribing
+
+Send `resources/subscribe` with the resource URI:
+
+```json
+{
+	"jsonrpc": "2.0",
+	"id": 7,
+	"method": "resources/subscribe",
+	"params": { "uri": "https://node.example.com:9926/Product/42" }
+}
+```
+
+A successful subscribe returns an empty result:
+
+```json
+{ "jsonrpc": "2.0", "id": 7, "result": {} }
+```
+
+- `params.uri` is required and must be a string — otherwise `-32602` (`resources/subscribe requires params.uri`).
+- Re-subscribing to the same URI is idempotent: the prior subscription is stopped and replaced.
+- The URI is persisted on the durable `mcp_session` record so it can be restored after an SSE reconnect (see [Resuming a dropped stream](#resuming-a-dropped-stream)).
+
+### Which URIs are subscribable
+
+Only **row-backed application resources** can be subscribed to — the `https://` / `http://` URIs that mirror an exported `Resource` (the same ones `resources/list` advertises on the application profile). The URI's path is matched against the `Resources` registry, and the resource is subscribable only if its class implements `subscribe`. Anything else returns `-32602`:
+
+```json
+{ "error": { "code": -32602, "message": "resource is not subscribable: harper://schema/data/product" } }
+```
+
+Synthetic `harper://*` metadata URIs (`harper://about`, `harper://openapi`, `harper://schema/...`, `harper://operations`) have no change source and are **not** subscribable. They participate in `notifications/resources/list_changed` only.
+
+### Record vs. collection URIs
+
+The granularity of a subscription is determined by the path:
+
+| URI form                       | Watches                                                      |
+| ------------------------------ | ------------------------------------------------------------ |
+| `https://host:port/Product/42` | The single record with primary key `42`.                     |
+| `https://host:port/Product`    | The whole `Product` table (any record insert/update/delete). |
+
+A collection URI (no record key — the form `resources/list` advertises) subscribes to the entire table; a record URI narrows the watch to one primary key.
+
+Subscriptions use `omitCurrent` semantics: Harper does **not** replay the current value at subscribe time. You only receive notifications for changes that commit _after_ the subscription is established. The notification carries no snapshot — re-read the resource (or call the corresponding `get_*` tool) to fetch the new state.
+
+## The `notifications/resources/updated` push
+
+On each committed change to a subscribed resource, Harper pushes a notification onto the session's GET-SSE channel:
+
+```json
+{
+	"jsonrpc": "2.0",
+	"method": "notifications/resources/updated",
+	"params": { "uri": "https://node.example.com:9926/Product/42" }
+}
+```
+
+There is no diff payload — `params.uri` is the only field. The client decides whether and how to re-read.
+
+## Unsubscribing
+
+Send `resources/unsubscribe` with the same URI:
+
+```json
+{
+	"jsonrpc": "2.0",
+	"id": 8,
+	"method": "resources/unsubscribe",
+	"params": { "uri": "https://node.example.com:9926/Product/42" }
+}
+```
+
+- `params.uri` is required (`-32602` otherwise).
+- Unsubscribing a URI that was never subscribed is a no-op and still returns `{}`.
+
+Subscriptions are also torn down automatically when the session's GET-SSE stream closes — via explicit `DELETE /mcp`, idle-timeout eviction from `system.mcp_session`, a dropped TCP connection, or an idle-prune sweep.
+
+## Scope and durability
+
+Subscriptions are **per-worker**: a subscription is bound to the worker that holds the session's SSE stream, and the audit-log change feed delivers commits locally on that worker. The live subscription objects can't be persisted, but the durable list of subscribed URIs lives on the `mcp_session` record, which is how they survive a reconnect.
+
+## Resuming a dropped stream
+
+Every frame Harper sends on the GET-SSE channel carries a monotonic SSE event id (the `id:` field). Harper keeps a bounded per-session **replay buffer** of the most recent 100 frames. When a dropped connection reconnects, the client sends the id of the last frame it saw in the standard `Last-Event-ID` header:
+
+```
+GET /mcp HTTP/1.1
+Mcp-Session-Id: 0c8f...
+Last-Event-ID: 137
+```
+
+Harper replays every buffered frame with a higher id (exclusive) before live frames resume, so a brief network blip doesn't drop `notifications/resources/updated` or `list_changed` events. On reconnect, Harper also restores the session's persisted subscriptions from the `mcp_session` record (best-effort — a URI that is no longer subscribable is dropped).
+
+Caveats, all best-effort by design:
+
+- **Buffer bound.** Only the last 100 frames are retained; a client that was disconnected long enough to miss more than 100 frames will not get the older ones. A non-numeric `Last-Event-ID` replays whatever is in the buffer.
+- **Per-worker.** The replay buffer and event-id sequence live on the worker that served the original stream. If the reconnecting `GET` lands on a different worker (one that never held the prior stream), its buffer is empty and there is nothing to replay. This is the same per-worker binding that scopes sessions and subscriptions.
+
+## Not yet supported
+
+See [the v1 out-of-scope list](./overview.md#out-of-scope-for-v1). Notably, cross-worker session sharing is deferred, so subscription delivery and `Last-Event-ID` replay are both best-effort across a reconnect that changes workers.

--- a/reference/mcp/tools-and-resources.md
+++ b/reference/mcp/tools-and-resources.md
@@ -120,7 +120,7 @@ This is independent of the `http` exportType — the only switch that operators 
 
 ## Resources surface
 
-Both profiles serve `resources/list`, `resources/read`, and `resources/templates/list`. The resources are static (no `resources/subscribe` in v1).
+Both profiles serve `resources/list`, `resources/read`, and `resources/templates/list`. Row-backed application resources can additionally be watched with `resources/subscribe` — see [MCP Resource Subscriptions](./subscriptions.md).
 
 ### `harper://` URIs
 

--- a/sidebarsReference.ts
+++ b/sidebarsReference.ts
@@ -254,6 +254,11 @@ const sidebars: SidebarsConfig = {
 				},
 				{
 					type: 'doc',
+					id: 'mcp/subscriptions',
+					label: 'Resource Subscriptions',
+				},
+				{
+					type: 'doc',
 					id: 'mcp/migration',
 					label: 'Migration',
 				},


### PR DESCRIPTION
## Summary

Documents the MCP v1 features that shipped in harper#1404 but were missing from the reference docs: `resources/subscribe` / `resources/unsubscribe`, `notifications/resources/updated`, and `Last-Event-ID` stream resumability. Tagged `v5.1.10`.

- **`reference/mcp/overview.md`** — adds "Resource subscriptions" and "Resumable notification streams" capability bullets; removes `resources/subscribe` and `Last-Event-ID` resumability from the now-stale "Out of scope for v1" list (they are implemented).
- **`reference/mcp/subscriptions.md`** (new) — the full subscription surface: the open-GET prerequisite, which URIs are subscribable (row-backed application resources only; `harper://*` is `list_changed`-only), record vs. collection granularity, `omitCurrent` semantics, the `notifications/resources/updated` payload, per-worker scope + durable URI restore on reconnect, and `Last-Event-ID` replay (100-frame bound, per-worker caveats).
- **`reference/mcp/tools-and-resources.md`** — corrects the "resources are static (no `resources/subscribe`)" note.
- **`sidebarsReference.ts`** — adds the new page.

## Scope

Documents the **working** surface only. Author opt-in paths — custom `mcpTools` handlers receiving the streaming context, prompts authoring, and progress / server→client emission — are reachable only through custom tools, which don't register at runtime today (harper#1448). Those are deliberately **not** documented here; they'll follow once #1448 lands.

## Verification

`npm run format:check` clean; `npm run build` succeeds with all new anchors resolving. (The one build-time broken-anchor warning is pre-existing in `release-notes/v5-lincoln/5.1` and untouched by this PR.)

Facts were verified against `harper` `origin/main` source (capabilities, error codes/messages, URI semantics, `omitCurrent`, the 100-frame replay buffer, per-worker behavior). Cross-model review: Codex CLI reviewed the diff against those facts and found no substantive issues (one wording clarification applied); Gemini was unavailable this pass (CLI auth/key error), so this is a single-model review.

Resolves #533. Documents HarperFast/harper#1404.

_Generated by an LLM (Claude Opus 4.8); reviewed by @kbernhardy._
