### PR TITLE
docs(database): add data-safety note for programmatic writes/deletes

### DIFF
--- a/reference/database/api.md
+++ b/reference/database/api.md
@@ -51,6 +51,10 @@ for await (const record of Product.search(query)) {
 
 For the full set of methods available on table classes, see the [Resource API](../resources/resource-api.md).
 
+:::warning Data safety
+Programmatic `update`, `patch`, and `delete` calls operate directly on stored data, which may be live production data. A query that matches more records than intended — or a delete issued without confirmation — can be destructive and is not easily reversible. Scope destructive operations with specific conditions, validate the affected set before writing, and gate them behind your application's approval and authorization controls.
+:::
+
 ## `databases`
 
 `databases` is an object whose properties are Harper databases. Each database contains its tables as properties, the same way `tables` does for the default database. In fact, `databases.data === tables` is always true.


### PR DESCRIPTION
## Summary

Adds a **"Data safety"** warning to the `tables` section of [`reference/database/api.md`](reference/database/api.md): programmatic `update`/`patch`/`delete` operate directly on stored (possibly production) data, an over-broad query can be destructive and isn't easily reversible, so scope with specific conditions, validate the affected set, and gate behind approval/authorization controls.

## Why

This guidance previously lived only in the `@harperfast/skills` `programmatic-table-requests` rule. As that rule migrates from hand-authored to docs-generated ([skills#63](https://github.com/HarperFast/skills/pull/63)), a pure regeneration drops the caution because it had no canonical source. Promoting it here keeps the safety guidance in the canonical reference (where all readers see it) and lets it round-trip through generation rather than being hand-grafted back into the rule.

It lands inside the `tables` section that skills#63 sources, so once this merges the rule regenerates with the caution intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)