### PR TITLE
docs(database): clarify tables/databases are process-wide and importable

### DIFF
--- a/reference/database/api.md
+++ b/reference/database/api.md
@@ -14,6 +14,12 @@ Harper exposes a set of global variables and functions that JavaScript code (in 
 
 `tables` is an object whose properties are the tables in the default database (`data`). Each table defined in your `schema.graphql` file is available as a property, and the value is the table class that implements the [Resource API](../resources/resource-api.md).
 
+`tables` and `databases` are **live, process-wide** objects: the same instance is shared by every module Harper loads — resources, scripts, plugins, and a framework's server-side render (SSR) entry alike. You can use `tables` as a bare global, or import it from the `harper` package; both resolve to the same object. Importing is preferred for clarity and types (see [Module Loading](../components/javascript-environment.md#module-loading)):
+
+```javascript
+import { tables } from 'harper';
+```
+
 ```graphql
 # schema.graphql
 type Product @table {


### PR DESCRIPTION
## Summary

Adds a clarification to the `tables` section of [`reference/database/api.md`](reference/database/api.md): `tables` and `databases` are **live, process-wide** objects shared by every module Harper loads — resources, scripts, plugins, and a framework's SSR render entry — accessible as a bare global or via `import { tables } from 'harper'` (same instance, importing preferred).

## Why

Readers (and coding agents) were inferring that table access is limited to "resources or scripts," which pushed SSR code toward workarounds like fetching the app's own REST API over loopback. This was reported against the `@harperfast/skills` rules ([skills#65](https://github.com/HarperFast/skills/pull/65)).

Landing it here (rather than only in the skills rule) makes it canonical and lets the `programmatic-table-requests` rule pick it up automatically when it regenerates from this section ([skills#63](https://github.com/HarperFast/skills/pull/63) migrates that rule to docs-driven generation). The Vite-specific "reading data during SSR" wiring belongs in the forthcoming Vite reference page (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)