### PR TITLE
chore(intake): issue types, simplified forms, and config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Harper Discussions
+    url: https://github.com/HarperFast/documentation/discussions
+    about: Questions about using Harper or the docs? Start a discussion — issues here are for documentation work (content and site).
+  - name: 📖 Harper Documentation
+    url: https://docs.harperdb.io/
+    about: Looking for how to use a Harper feature? Search the docs first.

--- a/.github/ISSUE_TEMPLATE/content-issue.yml
+++ b/.github/ISSUE_TEMPLATE/content-issue.yml
@@ -1,6 +1,7 @@
 name: 📝 Content Issue
 description: Report problems with existing documentation content (typos, errors, confusing sections, outdated information)
-labels: ['content', 'bug']
+type: Bug
+labels: ['content']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/content-issue.yml
+++ b/.github/ISSUE_TEMPLATE/content-issue.yml
@@ -1,82 +1,23 @@
 name: 📝 Content Issue
-description: Report problems with existing documentation content (typos, errors, confusing sections, outdated information)
+description: Report a problem with existing documentation (error, confusing, or outdated content)
 type: Bug
 labels: ['content']
 body:
   - type: markdown
     attributes:
-      value: |
-        Thanks for helping us improve our documentation! Use this template to report issues with existing content such as typos, errors, confusing sections, or outdated information.
-
-        For platform/site functionality issues, please use the "Platform Bug" template instead.
-
-  - type: dropdown
-    id: issue-type
-    attributes:
-      label: Issue Type
-      description: What kind of content issue is this?
-      options:
-        - Incorrect information
-        - Missing information
-        - Confusing/unclear content
-        - Typo or formatting error
-        - Outdated information
-        - Other
-    validations:
-      required: true
-
+      value: 'For a problem with the site itself (search, navigation, build), use the **Platform Bug** template instead.'
   - type: input
-    id: content-location
+    id: location
     attributes:
-      label: Content Location
-      description: URL or section where the issue is located. Make sure to include the version number too.
-      placeholder: "https://docs.harperdb.io/docs/getting-started/#harper-basics or '(4.6) Getting Started > Harper Basics'"
+      label: Page or URL
+      description: Where is the problem? (optional, but it helps a lot)
+      placeholder: https://docs.harperdb.io/... or the page title
     validations:
-      required: true
-
+      required: false
   - type: textarea
-    id: issue-description
+    id: details
     attributes:
       label: What's wrong?
-      description: Describe the issue with the current content
-      placeholder: "Be as specific as possible about what's incorrect, missing, or confusing"
+      description: Describe the error, confusion, or outdated content — and what would be correct, if you know.
     validations:
       required: true
-
-  - type: textarea
-    id: suggested-improvement
-    attributes:
-      label: Suggested improvement
-      description: How would you improve this content? (optional)
-      placeholder: 'What would make this clearer or more accurate?'
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional context
-      description: Any other context that might be helpful
-      placeholder: 'Screenshots, related issues, etc.'
-
-  - type: dropdown
-    id: contribution-intent
-    attributes:
-      label: Are you planning to fix this issue?
-      description: Let us know if you'd like to contribute the fix!
-      options:
-        - 'No, just reporting the issue'
-        - 'Maybe, depending on complexity'
-        - "Yes, I'll submit a PR to fix this"
-        - "Yes, but I'm a first-time contributor and could use guidance"
-    validations:
-      required: true
-
-  - type: checkboxes
-    id: first-time-contributor
-    attributes:
-      label: First-time contributor support
-      description: Check any that apply (only if you're planning to contribute)
-      options:
-        - label: I'm new to contributing and would appreciate guidance on the process
-        - label: I'd like help understanding the project structure
-        - label: I need assistance with setting up the development environment
-        - label: I'm comfortable contributing but new to this project specifically

--- a/.github/ISSUE_TEMPLATE/content-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-request.yml
@@ -1,93 +1,22 @@
 name: 📚 Content Request
-description: Request new documentation or coverage for undocumented features, APIs, or functionality
+description: Request new or expanded documentation
 type: Feature
 labels: ['content']
 body:
   - type: markdown
     attributes:
-      value: |
-        Thanks for helping us identify documentation gaps! Use this template to request new documentation for undocumented features, missing API coverage, or other content needs.
-
-        For platform/site feature requests, please use the "Platform Feature Request" template instead.
-
-  - type: dropdown
-    id: request-type
+      value: 'For a docs-site feature (search, navigation, tooling), use the **Platform Feature Request** template instead.'
+  - type: textarea
+    id: details
     attributes:
-      label: Request Type
-      description: What kind of documentation is needed?
-      options:
-        - Undocumented existing feature
-        - New feature documentation
-        - API/method documentation
-        - Tutorial or guide
-        - Code examples
-        - Missing section coverage
-        - Other
+      label: What needs documenting?
+      description: Describe the feature, API, or topic that needs documentation.
     validations:
       required: true
-
   - type: textarea
-    id: what-needs-documenting
+    id: context
     attributes:
-      label: What needs to be documented?
-      description: Describe what functionality, feature, or topic needs documentation
-      placeholder: "Be specific about what's missing or undocumented"
+      label: Why / context
+      description: What are you trying to do, and anything that would help us write it? (optional)
     validations:
-      required: true
-
-  - type: textarea
-    id: suggested-location
-    attributes:
-      label: Where should this be documented?
-      description: Suggest where in the docs this content should live
-      placeholder: 'New section, existing page URL, or general area'
-
-  - type: textarea
-    id: use-case
-    attributes:
-      label: Why is this needed?
-      description: What use case or problem would this documentation solve?
-      placeholder: 'How would this help users? What are people trying to accomplish?'
-
-  - type: textarea
-    id: existing-information
-    attributes:
-      label: Existing information
-      description: Do you have any information, examples, or resources that could help?
-      placeholder: 'Code snippets, API responses, screenshots, links to related features, etc.'
-
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority/Impact
-      description: How important is this documentation gap?
-      options:
-        - 'High - critical for user success'
-        - 'Medium - important but not urgent'
-        - 'Low - nice to have'
-    validations:
-      required: true
-
-  - type: dropdown
-    id: contribution-intent
-    attributes:
-      label: Are you planning to fix this issue?
-      description: Let us know if you'd like to contribute the fix!
-      options:
-        - 'No, just reporting the issue'
-        - 'Maybe, depending on complexity'
-        - "Yes, I'll submit a PR to fix this"
-        - "Yes, but I'm a first-time contributor and could use guidance"
-    validations:
-      required: true
-
-  - type: checkboxes
-    id: first-time-contributor
-    attributes:
-      label: First-time contributor support
-      description: Check any that apply (only if you're planning to contribute)
-      options:
-        - label: I'm new to contributing and would appreciate guidance on the process
-        - label: I'd like help understanding the project structure
-        - label: I need assistance with setting up the development environment
-        - label: I'm comfortable contributing but new to this project specifically
+      required: false

--- a/.github/ISSUE_TEMPLATE/content-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-request.yml
@@ -1,6 +1,7 @@
 name: 📚 Content Request
 description: Request new documentation or coverage for undocumented features, APIs, or functionality
-labels: ['content', 'enhancement']
+type: Feature
+labels: ['content']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/platform-bug.yml
+++ b/.github/ISSUE_TEMPLATE/platform-bug.yml
@@ -1,6 +1,7 @@
 name: 🐛 Platform Bug
 description: Report issues with the documentation site's functionality (broken features, UI problems, performance issues)
-labels: ['platform', 'bug']
+type: Bug
+labels: ['platform']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/platform-bug.yml
+++ b/.github/ISSUE_TEMPLATE/platform-bug.yml
@@ -1,125 +1,23 @@
 name: 🐛 Platform Bug
-description: Report issues with the documentation site's functionality (broken features, UI problems, performance issues)
+description: Report a problem with the documentation site itself (search, navigation, build, styling)
 type: Bug
 labels: ['platform']
 body:
   - type: markdown
     attributes:
-      value: |
-        Thanks for reporting a platform issue! Use this template for problems with the site's functionality such as broken search, navigation issues, mobile problems, or performance issues.
-
-        For content-related issues (typos, errors, confusing text), please use the "Content Issue" template instead.
-
-  - type: input
-    id: bug-summary
-    attributes:
-      label: Bug Summary
-      description: Brief summary of the issue
-      placeholder: "Search doesn't work on mobile, navigation menu broken, etc."
-    validations:
-      required: true
-
+      value: 'For a problem with documentation content (errors, typos, unclear text), use the **Content Issue** template instead.'
   - type: textarea
-    id: steps-to-reproduce
+    id: details
     attributes:
-      label: Steps to Reproduce
-      description: How can we reproduce this issue?
-      placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
+      label: What's broken?
+      description: What happened, and what did you expect? Include steps to reproduce if you can.
     validations:
       required: true
-
-  - type: textarea
-    id: expected-behavior
-    attributes:
-      label: Expected Behavior
-      description: What should happen?
-      placeholder: 'What did you expect to happen?'
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: Actual Behavior
-      description: What actually happened?
-      placeholder: 'What actually happened instead?'
-    validations:
-      required: true
-
   - type: input
     id: url
     attributes:
       label: Page URL
-      description: Where did this issue occur?
-      placeholder: 'https://docs.example.com/page'
-
-  - type: dropdown
-    id: browsers
-    attributes:
-      label: Browser
-      description: Which browser are you using?
-      multiple: true
-      options:
-        - Chrome
-        - Firefox
-        - Safari
-        - Edge
-        - Mobile Safari (iOS)
-        - Chrome Mobile (Android)
-        - Other
-
-  - type: input
-    id: device
-    attributes:
-      label: Device/OS
-      description: What device and operating system?
-      placeholder: 'Windows 11, macOS 14, iPhone 15, etc.'
-
-  - type: textarea
-    id: console-errors
-    attributes:
-      label: Console Errors
-      description: Any console errors or network issues? (Check browser dev tools)
-      placeholder: 'Copy/paste any error messages from the browser console'
-
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots or Videos
-      description: Add screenshots or videos to help explain the problem
-      placeholder: 'Drag and drop images here or paste URLs'
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Any other relevant information
-      placeholder: 'Frequency of issue, workarounds, related issues, etc.'
-
-  - type: dropdown
-    id: contribution-intent
-    attributes:
-      label: Are you planning to fix this issue?
-      description: Let us know if you'd like to contribute the fix!
-      options:
-        - 'No, just reporting the issue'
-        - 'Maybe, depending on complexity'
-        - "Yes, I'll submit a PR to fix this"
-        - "Yes, but I'm a first-time contributor and could use guidance"
+      description: Where did it happen? (optional)
+      placeholder: https://docs.harperdb.io/...
     validations:
-      required: true
-
-  - type: checkboxes
-    id: first-time-contributor
-    attributes:
-      label: First-time contributor support
-      description: Check any that apply (only if you're planning to contribute)
-      options:
-        - label: I'm new to contributing and would appreciate guidance on the process
-        - label: I'd like help understanding the project structure
-        - label: I need assistance with setting up the development environment
-        - label: I'm comfortable contributing but new to this project specifically
+      required: false

--- a/.github/ISSUE_TEMPLATE/platform-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/platform-feature-request.yml
@@ -1,123 +1,15 @@
 name: ⚡️ Platform Feature Request
-description: Suggest new functionality or improvements for the documentation site itself
+description: Suggest an improvement to the documentation site itself
 type: Feature
 labels: ['platform']
 body:
   - type: markdown
     attributes:
-      value: |
-        Thanks for suggesting an improvement! Use this template to request new functionality or improvements for the documentation site itself (search improvements, navigation changes, new tools, etc.).
-
-        For requesting new documentation content, please use the "Content Request" template instead.
-
+      value: 'To request new documentation content, use the **Content Request** template instead.'
   - type: textarea
-    id: feature-summary
+    id: details
     attributes:
-      label: Feature Summary
-      description: Brief summary of the requested feature or improvement
-      placeholder: 'What functionality would you like to see added or improved?'
+      label: What would you like to see?
+      description: Describe the improvement and the problem it would solve.
     validations:
       required: true
-
-  - type: dropdown
-    id: feature-category
-    attributes:
-      label: Feature Category
-      description: What area of the platform does this relate to?
-      options:
-        - Search functionality
-        - Navigation/menu
-        - Page layout/design
-        - Mobile experience
-        - Performance
-        - Accessibility
-        - Developer tools
-        - Content management
-        - User experience
-        - Analytics/tracking
-        - Other
-    validations:
-      required: true
-
-  - type: textarea
-    id: problem-solved
-    attributes:
-      label: Problem This Solves
-      description: What problem would this feature solve?
-      placeholder: 'Describe the current pain point or limitation this would address'
-    validations:
-      required: true
-
-  - type: textarea
-    id: proposed-solution
-    attributes:
-      label: Proposed Solution
-      description: How would you like this to work?
-      placeholder: 'Describe your ideal implementation of this feature'
-    validations:
-      required: true
-
-  - type: textarea
-    id: user-stories
-    attributes:
-      label: User Stories
-      description: How would different users benefit from this feature?
-      placeholder: |
-        As a [type of user], I want [goal] so that [benefit]
-
-        Example: "As a developer, I want better search filtering so that I can quickly find API references"
-
-  - type: textarea
-    id: alternatives-considered
-    attributes:
-      label: Alternatives Considered
-      description: Are there other ways to solve this problem?
-      placeholder: 'What other solutions have you considered?'
-
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority/Impact
-      description: How important is this feature?
-      options:
-        - 'High - critical for user success'
-        - 'Medium - important but not urgent'
-        - 'Low - nice to have'
-
-  - type: textarea
-    id: examples
-    attributes:
-      label: Examples or References
-      description: Are there examples of this feature done well elsewhere?
-      placeholder: 'Links to other sites, mockups, or examples that demonstrate this feature'
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Any other relevant information
-      placeholder: 'Technical considerations, constraints, related requests, etc.'
-
-  - type: dropdown
-    id: contribution-intent
-    attributes:
-      label: Are you planning to fix this issue?
-      description: Let us know if you'd like to contribute the fix!
-      options:
-        - 'No, just reporting the issue'
-        - 'Maybe, depending on complexity'
-        - "Yes, I'll submit a PR to fix this"
-        - "Yes, but I'm a first-time contributor and could use guidance"
-    validations:
-      required: true
-
-  - type: checkboxes
-    id: first-time-contributor
-    attributes:
-      label: First-time contributor support
-      description: Check any that apply (only if you're planning to contribute)
-      options:
-        - label: I'm new to contributing and would appreciate guidance on the process
-        - label: I'd like help understanding the project structure
-        - label: I need assistance with setting up the development environment
-        - label: I'm comfortable contributing but new to this project specifically

--- a/.github/ISSUE_TEMPLATE/platform-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/platform-feature-request.yml
@@ -1,6 +1,7 @@
 name: ⚡️ Platform Feature Request
 description: Suggest new functionality or improvements for the documentation site itself
-labels: ['platform', 'enhancement']
+type: Feature
+labels: ['platform']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Two related intake changes for the docs-repo PM cleanup:

### 1. Issue types replace kind labels
Each form now sets a GitHub **issue type** and drops the kind label:
| Form | Was | Now |
|------|-----|-----|
| `content-issue` | `['content','bug']` | `type: Bug` + `['content']` |
| `content-request` | `['content','enhancement']` | `type: Feature` + `['content']` |
| `platform-bug` | `['platform','bug']` | `type: Bug` + `['platform']` |
| `platform-feature-request` | `['platform','enhancement']` | `type: Feature` + `['platform']` |

Prerequisite for retiring the `bug`/`enhancement` labels (done type-first, after existing issues are backfilled).

### 2. Drastically simplified forms
The forms were rarely completed (6–11 fields each: required issue-type/priority dropdowns, contribution-intent, first-timer checkboxes, user stories, browser/device/console, alternatives…). Each is cut to **one required free-text field + at most one optional field**:
- **Content Issue** — page/URL (optional) + what's wrong (required)
- **Content Request** — what needs documenting (required) + why/context (optional)
- **Platform Bug** — what's broken (required) + page URL (optional)
- **Platform Feature Request** — what would you like to see (required)

The old "issue type"/"priority" dropdowns are redundant now that the type is set by the form. Lower friction → more submissions; fields can be added back if a real need emerges.

### 3. `config.yml`
`blank_issues_enabled: false` + contact links (Discussions, docs site).

Area labels (`content`/`platform`) unchanged. No existing issues modified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)