### PR TITLE
docs(resources): parameterised resource paths and the `static path` field

### DIFF
--- a/reference/resources/overview.md
+++ b/reference/resources/overview.md
@@ -141,7 +141,7 @@ A resource's path can declare dynamic segments. A `:name` segment matches a sing
 export class Widget extends Resource {
 	// GET /widget/10/action/jump  ->  target.id === '10', target.action === 'jump'
 	static path = '/widget/:id/action/:action';
-	get(target) {
+	static get(target) {
 		return { id: target.id, action: target.action };
 	}
 }
@@ -149,7 +149,7 @@ export class Widget extends Resource {
 export class Files extends Resource {
 	// GET /files/a/b/c.txt  ->  target.rest === 'a/b/c.txt'
 	static path = '/files/*rest';
-	get(target) {
+	static get(target) {
 		return { path: target.rest };
 	}
 }

--- a/reference/resources/overview.md
+++ b/reference/resources/overview.md
@@ -120,14 +120,51 @@ Resources become HTTP/MQTT endpoints when they are exported. As the examples dem
 
 The shape of the export controls the resulting URL:
 
-| Export form                              | URL             | Notes                                                                        |
-| ---------------------------------------- | --------------- | ---------------------------------------------------------------------------- |
-| `export class Foo extends Resource {}`   | `/Foo/`         | The class name becomes the path segment. Path segments are case-sensitive.   |
-| `export const Bar = { Foo };`            | `/Bar/Foo/`     | Nest a class under an object to add a path prefix.                           |
-| `export const bar = { 'foo-baz': Foo };` | `/bar/foo-baz/` | Use object keys when you need lowercase, hyphens, or any non-identifier URL. |
-| `server.resources.set('my-path', Foo);`  | `/my-path/`     | Programmatic registration; useful when the path is dynamic.                  |
+| Export form                                 | URL             | Notes                                                                                                                          |
+| ------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `export class Foo extends Resource {}`      | `/Foo/`         | The class name becomes the path segment. Path segments are case-sensitive.                                                     |
+| `export const Bar = { Foo };`               | `/Bar/Foo/`     | Nest a class under an object to add a path prefix.                                                                             |
+| `export const bar = { 'foo-baz': Foo };`    | `/bar/foo-baz/` | Use object keys when you need lowercase, hyphens, or any non-identifier URL.                                                   |
+| `export { Foo as '/widget/:id' }`           | `/widget/:id`   | Rename the export to set the path directly, including a leading-slash top-level path. See [Path Parameters](#path-parameters). |
+| `static path = '/widget/:id'` (class field) | `/widget/:id`   | Declare the path on the class itself; overrides the export name. See [Path Parameters](#path-parameters).                      |
+| `server.resources.set('my-path', Foo);`     | `/my-path/`     | Programmatic registration; useful when the path is dynamic.                                                                    |
 
 URL path matching is case-sensitive — `/Foo/` and `/foo/` are different endpoints.
+
+### Path Parameters
+
+<VersionBadge version="v5.1.13" />
+
+A resource's path can declare dynamic segments. A `:name` segment matches a single path segment, and a `*name` segment is a catch-all that matches the rest of the path. Matched values are bound onto the request target so a handler reads them as `target.<name>`:
+
+```js
+export class Widget extends Resource {
+	// GET /widget/10/action/jump  ->  target.id === '10', target.action === 'jump'
+	static path = '/widget/:id/action/:action';
+	get(target) {
+		return { id: target.id, action: target.action };
+	}
+}
+
+export class Files extends Resource {
+	// GET /files/a/b/c.txt  ->  target.rest === 'a/b/c.txt'
+	static path = '/files/*rest';
+	get(target) {
+		return { path: target.rest };
+	}
+}
+```
+
+A bare `*` (no name) binds under `target.wildcard`. A wildcard must be the final segment of the path.
+
+**Declaring the path.** The path can come from a `static path` field on the class (the recommended lever, since it leaves the exports untouched) or from the export name (`export { Widget as '/widget/:id' }`). A `static path` takes precedence over the export name. In both forms:
+
+- A leading `/` makes the path **root-relative** (top-level), independent of the file's location — useful for fixed top-level routes such as `static path = '/.well-known/acme-challenge/:token'`.
+- A leading `./` or a bare name resolves **relative to the component directory**, the same as the default export-name behavior.
+
+**Resolution order.** Exact and static paths always win over parameterized ones — `/resource/admin` is matched by a `static`-pathed `/resource/admin` resource even when a `/resource/:id` resource is also registered. Among parameterized routes, more specific paths win: a literal segment beats a `:param`, which beats a `*` wildcard, compared left to right.
+
+Parameterized routes also surface in the generated OpenAPI document (as templated paths like `/widget/{id}/action/{action}`) and in MCP `resources/templates/list` (as `{param}` URI templates).
 
 ## Pages in This Section
 

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -437,6 +437,23 @@ Returns the number of records in the table. By default returns an approximate (f
 
 The name of the primary key attribute for the table.
 
+### `static path?: string`
+
+<VersionBadge version="v5.1.13" />
+
+Declares the URL path the resource is registered at, overriding the default export-name convention. A leading `/` makes the path root-relative (top-level); a leading `./` or a bare name resolves relative to the component directory. The path may contain `:name` (single-segment) and `*name` (trailing catch-all) parameters, whose matched values are bound onto the request target (e.g. `static path = '/widget/:id'` populates `target.id`).
+
+```js
+export class Widget extends Resource {
+	static path = '/widget/:id/action/:action';
+	get(target) {
+		// GET /widget/10/action/jump -> target.id === '10', target.action === 'jump'
+	}
+}
+```
+
+See [Exporting Resources as Endpoints → Path Parameters](./overview.md#path-parameters) for matching and precedence rules.
+
 ---
 
 ## Class-level metadata for MCP and OpenAPI

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -446,7 +446,7 @@ Declares the URL path the resource is registered at, overriding the default expo
 ```js
 export class Widget extends Resource {
 	static path = '/widget/:id/action/:action';
-	get(target) {
+	static get(target) {
 		// GET /widget/10/action/jump -> target.id === '10', target.action === 'jump'
 	}
 }


### PR DESCRIPTION
Documents the parameterised-path feature added in [harper#1460](https://github.com/HarperFast/harper/pull/1460): resources can declare `:param` and `*wildcard` path segments, via a `static path` field or the `export { Foo as '/path' }` rename form, with matched values bound onto the request target (`target.<name>`).

## Changes
- **`reference/resources/overview.md` → "Exporting Resources as Endpoints"**
  - Added table rows for the `export { Foo as '/path' }` rename form and the `static path` class field.
  - New **"Path Parameters"** subsection: `:name` (single-segment) and `*name` (trailing catch-all) binding to `target.<name>`; bare `*` → `target.wildcard`; declaring the path via `static path` vs the export name (static wins); leading-`/` root-relative vs `./`/bare component-relative; precedence (exact/static wins over parameterised, most-specific parameterised route wins); and a note that these surface in the OpenAPI doc (`/widget/{id}/...`) and MCP `resources/templates/list`.
- **`reference/resources/resource-api.md`**
  - Added a `static path?: string` entry cross-linking the overview section.

Both additions carry `<VersionBadge version="v5.1.13" />`.

## Verification
- `npm run format:check` clean.
- `npm run build` succeeds; the new `#path-parameters` anchor and the cross-link resolve. (The one broken-anchor warning is on the pre-existing `/release-notes/v5-lincoln/5.1` page, unrelated to this change.)

> **Version note:** I tagged the badges `v5.1.13` (next release after the current `v5.1.12`). Please bump if harper#1460 lands in a different release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)