### PR TITLE
Use hostname in controlled-flow replication example

### DIFF
--- a/reference/replication/overview.md
+++ b/reference/replication/overview.md
@@ -186,11 +186,11 @@ replication:
   databases:
     - data
   routes:
-    - host: node-two
+    - hostname: node-two
       replicates:
         sends: false
         receives: true
-    - host: node-three
+    - hostname: node-three
       replicates:
         sends: true
         receives: false


### PR DESCRIPTION
## Summary
The "Controlling Replication Flow" example in `reference/replication/overview.md` used `host:`, while the rest of the page (and the config schema) use `hostname:`. Both are accepted, but the inconsistency is confusing. Switched the example to `hostname:`.

## Context
Companion to the controlled-flow enforcement work for harper-pro#498 (HarperFast/harper-pro#506) and the schema validation that makes these fields first-class (HarperFast/harper#1529).

_Generated by an LLM (Claude Opus 4.8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)