### PR TITLE
docs(analytics): note get_analytics reads without a consistent snapshot

### DIFF
--- a/reference/analytics/operations.md
+++ b/reference/analytics/operations.md
@@ -130,6 +130,14 @@ Queries analytics data for a specific metric over a time range.
 ]
 ```
 
+### Read behavior
+
+`get_analytics` queries read against the latest committed data without holding a consistent read
+snapshot open for the duration of the query. This keeps long-running analytics scans easier on the
+rest of the system — a query never pins a snapshot that would otherwise block storage compaction
+for its duration. The trade-off is that results are not guaranteed to reflect a single point in
+time: rows written while the query is iterating may be included.
+
 ## Related
 
 - [Analytics Overview](./overview)

--- a/reference/analytics/operations.md
+++ b/reference/analytics/operations.md
@@ -133,9 +133,9 @@ Queries analytics data for a specific metric over a time range.
 ### Read behavior
 
 `get_analytics` queries read against the latest committed data without holding a consistent read
-snapshot open for the duration of the query. This keeps long-running analytics scans easier on the
-rest of the system — a query never pins a snapshot that would otherwise block storage compaction
-for its duration. The trade-off is that results are not guaranteed to reflect a single point in
+snapshot open for the duration of the query. This minimizes the impact of long-running analytics
+scans on the rest of the system — a query never pins a snapshot that would otherwise block storage
+compaction for its duration. The trade-off is that results are not guaranteed to reflect a single point in
 time: rows written while the query is iterating may be included.
 
 ## Related


### PR DESCRIPTION
## What

Adds a **Read behavior** note to the `get_analytics` operation reference explaining that these queries read against the latest committed data without holding a consistent read snapshot open for the duration of the scan.

## Why

Companion to [HarperFast/harper#35](https://github.com/HarperFast/harper/pull/35), which makes `get_analytics` scans run with snapshots disabled (RocksDB) so a long-running analytics query doesn't pin a snapshot that blocks storage compaction. The trade-off — results aren't guaranteed to reflect a single point in time — is worth calling out for users.

Note: `snapshot` is set internally by Harper for `get_analytics`; it is not a new user-facing request parameter, so this is a behavioral note rather than a new parameter row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)