### PR TITLE
Document `replicated: true` on `set_configuration`

### DIFF
--- a/reference/configuration/operations.md
+++ b/reference/configuration/operations.md
@@ -20,7 +20,13 @@ Modifies one or more Harper configuration parameters. **Requires a [restart](../
 
 `operation` _(required)_ — must be `set_configuration`
 
+`replicated` _(optional)_ <VersionBadge version="v5.1.0" /> — set to `true` to apply the same configuration change to all cluster nodes in a single call. The origin node applies the change first; if its local write fails, nothing is sent to peers. Requires replication to be configured.
+
 Additional properties correspond to configuration keys in underscore-separated format (e.g. `logging_level` for `logging.level`, `clustering_enabled` for `clustering.enabled`).
+
+:::warning Replicate cluster-appropriate parameters only
+A replicated call sends the exact same values to every node. Do not include node-local parameters — ports, `node.hostname`, `rootPath`, storage/log file paths, TLS certificate or key paths, or `replication.hostname`/`url`/`routes` — as they would overwrite each peer's local values.
+:::
 
 ### Body
 
@@ -37,6 +43,42 @@ Additional properties correspond to configuration keys in underscore-separated f
 ```json
 {
 	"message": "Configuration successfully set. You must restart HarperDB for new config settings to take effect."
+}
+```
+
+### Replicated body
+
+```json
+{
+	"operation": "set_configuration",
+	"http_corsAccessList": ["app.example.com"],
+	"replicated": true
+}
+```
+
+### Response: 200 (replicated)
+
+The `replicated` array reports per-node outcomes. A failed peer appears as `{ "status": "failed", "reason": "...", "node": "..." }` while `message` still reports overall success — always check the array when replicating.
+
+```json
+{
+	"message": "Configuration successfully set. You must restart Harper for new config settings to take effect.",
+	"replicated": [
+		{
+			"message": "Configuration successfully set. You must restart Harper for new config settings to take effect.",
+			"node": "node-2"
+		}
+	]
+}
+```
+
+To restart the whole cluster afterward, follow with [restart_service](../operations-api/operations.md#restart_service) using `"replicated": true` — it restarts nodes one at a time, so the cluster stays available:
+
+```json
+{
+	"operation": "restart_service",
+	"service": "http",
+	"replicated": true
 }
 ```
 

--- a/reference/configuration/operations.md
+++ b/reference/configuration/operations.md
@@ -20,7 +20,7 @@ Modifies one or more Harper configuration parameters. **Requires a [restart](../
 
 `operation` _(required)_ — must be `set_configuration`
 
-`replicated` _(optional)_ <VersionBadge version="v5.1.0" /> — set to `true` to apply the same configuration change to all cluster nodes in a single call. The origin node applies the change first; if its local write fails, nothing is sent to peers. Requires replication to be configured.
+`replicated` _(optional)_ <VersionBadge version="v5.2.0" /> — set to `true` to apply the same configuration change to all cluster nodes in a single call. The origin node applies the change first; if its local write fails, nothing is sent to peers. Requires replication to be configured.
 
 Additional properties correspond to configuration keys in underscore-separated format (e.g. `logging_level` for `logging.level`, `clustering_enabled` for `clustering.enabled`).
 

--- a/reference/operations-api/operations.md
+++ b/reference/operations-api/operations.md
@@ -795,11 +795,13 @@ Detailed documentation: [Configuration Overview](../configuration/overview.md)
 
 Updates configuration parameters in `harper-config.yaml`. A restart (`restart` or `restart_service`) is required for changes to take effect.
 
+Supports `"replicated": true` <VersionBadge version="v5.1.0" /> to apply the same change to all cluster nodes in one call; per-node outcomes are returned in the response's `replicated` array. Only send cluster-appropriate parameters when replicating — node-local parameters (ports, `node.hostname`, file paths, TLS material, `replication.hostname`/`url`/`routes`) would overwrite every peer's local values. To apply the change cluster-wide, follow with `restart_service` using `"replicated": true` (which restarts nodes one at a time). See [Configuration Operations](../configuration/operations.md#set-configuration) for details.
+
 ```json
 {
 	"operation": "set_configuration",
 	"logging_level": "trace",
-	"clustering_enabled": true
+	"replicated": true
 }
 ```
 

--- a/reference/operations-api/operations.md
+++ b/reference/operations-api/operations.md
@@ -838,7 +838,7 @@ Restarts all Harper processes. May take up to 60 seconds.
 
 ### `restart_service`
 
-Restarts a specific service. `service` must be one of: `http_workers`, `clustering_config`, `clustering`. Supports `"replicated": true` for a rolling cluster restart.
+Restarts a specific service. `service` must be one of: `http`, `http_workers`, `custom_functions`, `harperdb` (all currently restart the HTTP workers). Supports `"replicated": true` for a rolling cluster restart.
 
 ```json
 { "operation": "restart_service", "service": "http_workers" }

--- a/reference/operations-api/operations.md
+++ b/reference/operations-api/operations.md
@@ -795,7 +795,7 @@ Detailed documentation: [Configuration Overview](../configuration/overview.md)
 
 Updates configuration parameters in `harper-config.yaml`. A restart (`restart` or `restart_service`) is required for changes to take effect.
 
-Supports `"replicated": true` <VersionBadge version="v5.1.0" /> to apply the same change to all cluster nodes in one call; per-node outcomes are returned in the response's `replicated` array. Only send cluster-appropriate parameters when replicating — node-local parameters (ports, `node.hostname`, file paths, TLS material, `replication.hostname`/`url`/`routes`) would overwrite every peer's local values. To apply the change cluster-wide, follow with `restart_service` using `"replicated": true` (which restarts nodes one at a time). See [Configuration Operations](../configuration/operations.md#set-configuration) for details.
+Supports `"replicated": true` <VersionBadge version="v5.2.0" /> to apply the same change to all cluster nodes in one call; per-node outcomes are returned in the response's `replicated` array. Only send cluster-appropriate parameters when replicating — node-local parameters (ports, `node.hostname`, file paths, TLS material, `replication.hostname`/`url`/`routes`) would overwrite every peer's local values. To apply the change cluster-wide, follow with `restart_service` using `"replicated": true` (which restarts nodes one at a time). See [Configuration Operations](../configuration/operations.md#set-configuration) for details.
 
 ```json
 {

--- a/release-notes/v5-lincoln/5.1.md
+++ b/release-notes/v5-lincoln/5.1.md
@@ -203,6 +203,10 @@ This is useful for node-local state — per-node counters, cache metadata, or an
 
 ## Configuration
 
+### Replicated `set_configuration`
+
+The `set_configuration` operation now accepts `"replicated": true` to apply a configuration change to all cluster nodes in a single Operations API call, with per-node outcomes reported in the response's `replicated` array. Only cluster-appropriate parameters should be replicated — see [Configuration Operations](/reference/v5/configuration/operations#set-configuration).
+
 ### `HARPER_CONFIG` environment variable
 
 `HARPER_CONFIG` is now the recommended way to specify the configuration file location:

--- a/release-notes/v5-lincoln/5.1.md
+++ b/release-notes/v5-lincoln/5.1.md
@@ -203,10 +203,6 @@ This is useful for node-local state — per-node counters, cache metadata, or an
 
 ## Configuration
 
-### Replicated `set_configuration`
-
-The `set_configuration` operation now accepts `"replicated": true` to apply a configuration change to all cluster nodes in a single Operations API call, with per-node outcomes reported in the response's `replicated` array. Only cluster-appropriate parameters should be replicated — see [Configuration Operations](/reference/v5/configuration/operations#set-configuration).
-
 ### `HARPER_CONFIG` environment variable
 
 `HARPER_CONFIG` is now the recommended way to specify the configuration file location:

--- a/release-notes/v5-lincoln/5.2.md
+++ b/release-notes/v5-lincoln/5.2.md
@@ -1,0 +1,15 @@
+---
+title: '5.2'
+---
+
+# 5.2 Release Notes
+
+### Patch Releases
+
+All patch release notes for 5.2.x are available on the [releases page](https://github.com/HarperFast/harper/releases?q=v5.2&expanded=true).
+
+## Configuration
+
+### Replicated `set_configuration`
+
+The `set_configuration` operation now accepts `"replicated": true` to apply a configuration change to all cluster nodes in a single Operations API call, with per-node outcomes reported in the response's `replicated` array. Only cluster-appropriate parameters should be replicated — see [Configuration Operations](/reference/v5/configuration/operations#set-configuration).


### PR DESCRIPTION
Companion to HarperFast/harper#1556 (closes HarperFast/harper#660 / CORE-2939 on the feature side).

- `reference/operations-api/operations.md`: `set_configuration` now notes `replicated: true` support, the per-node `replicated[]` response, the node-local-params footgun, and the `restart_service {replicated: true}` follow-up.
- `reference/configuration/operations.md`: full treatment — `replicated` param, replicated request/response examples (including the failed-peer shape and the "check the array, `message` alone reads as success" caveat), warning block listing node-local params, and the sequential cluster-restart workflow.
- `release-notes/v5-lincoln/5.1.md`: release-note entry under Configuration.

`<VersionBadge version="v5.1.0" />` on the new surface per repo conventions.

Generated by an LLM (Claude Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)