### PR TITLE
Document threads.preload config option

### DIFF
--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -70,10 +70,15 @@ threads:
 ```yaml
 threads:
   preload: dd-trace/init
-  # or several:
-  # preload:
-  #   - dd-trace/init
-  #   - /opt/instrumentation/agent.js
+```
+
+Or several modules:
+
+```yaml
+threads:
+  preload:
+    - dd-trace/init
+    - /opt/instrumentation/agent.js
 ```
 
 ---

--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -65,11 +65,11 @@ threads:
 - `maxHeapMemory` — Heap limit per thread (MB)
 - `heapSnapshotNearLimit` — Write a `.heapsnapshot` file when a thread nears its heap limit (loadable in Chrome DevTools Memory tab); _Default_: `false`. See [Worker Thread Debugging](./debugging.md#heap-snapshots-near-the-limit)
 - `debug` — Enable Node.js inspector; sub-options: `port`, `startingPort`, `host`, `waitForDebugger`. See [Worker Thread Debugging](./debugging.md)
-- `preload` <VersionBadge version="v5.2.0" /> — Module, or list of modules, to load (via Node's `--require`) before any Harper or application module on each worker thread. Intended for instrumentation/APM agents (e.g. `dd-trace`) that must load first to instrument subsequent module loads. Bare specifiers (e.g. `dd-trace/init`) resolve against the `node_modules` of your installed [components](../components/overview.md) — so the agent can be shipped as a dependency of a deployed component — and absolute paths are also accepted. Applies to worker threads only (not under Bun).
+- `preload` <VersionBadge version="v5.2.0" /> — Module, or list of modules, to load (via Node's `--import`) before any Harper or application module on each worker thread. Intended for instrumentation/APM agents that must load first to instrument subsequent module loads. Use the agent's ESM/register entry — e.g. `dd-trace/register.js`, which registers the loader hooks that instrument worker threads (where Harper runs its work); the plain `dd-trace/init` (`--require`) entry only covers the main thread. Bare specifiers resolve against the `node_modules` of your installed [components](../components/overview.md) — so the agent can be shipped as a dependency of a deployed component — and absolute paths are also accepted. Applies to worker threads only (not under Bun).
 
 ```yaml
 threads:
-  preload: dd-trace/init
+  preload: dd-trace/register.js
 ```
 
 Or several modules:
@@ -77,8 +77,15 @@ Or several modules:
 ```yaml
 threads:
   preload:
-    - dd-trace/init
-    - /opt/instrumentation/agent.js
+    - dd-trace/register.js
+    - /opt/instrumentation/agent.mjs
+```
+
+- `preloadRequire` <VersionBadge version="v5.2.0" /> — Same as `preload`, but loads modules via Node's `--require` (CommonJS) instead of `--import`. Use this for agents that document the `--require` path and do not need ESM loader hooks (e.g. `dd-trace/init`, Dynatrace OneAgent). Same resolution rules as `preload`.
+
+```yaml
+threads:
+  preloadRequire: dd-trace/init
 ```
 
 ---

--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -65,6 +65,16 @@ threads:
 - `maxHeapMemory` — Heap limit per thread (MB)
 - `heapSnapshotNearLimit` — Write a `.heapsnapshot` file when a thread nears its heap limit (loadable in Chrome DevTools Memory tab); _Default_: `false`. See [Worker Thread Debugging](./debugging.md#heap-snapshots-near-the-limit)
 - `debug` — Enable Node.js inspector; sub-options: `port`, `startingPort`, `host`, `waitForDebugger`. See [Worker Thread Debugging](./debugging.md)
+- `preload` <VersionBadge version="v5.2.0" /> — Module, or list of modules, to load (via Node's `--require`) before any Harper or application module on each worker thread. Intended for instrumentation/APM agents (e.g. `dd-trace`) that must load first to instrument subsequent module loads. Bare specifiers (e.g. `dd-trace/init`) resolve against the `node_modules` of your installed [components](../components/overview.md) — so the agent can be shipped as a dependency of a deployed component — and absolute paths are also accepted. Applies to worker threads only (not under Bun).
+
+```yaml
+threads:
+  preload: dd-trace/init
+  # or several:
+  # preload:
+  #   - dd-trace/init
+  #   - /opt/instrumentation/agent.js
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the new `threads.preload` configuration option in the config reference.

`threads.preload` loads a module (or list of modules) via Node's `--require` before any Harper or application module on each worker thread — the earliest point in a worker's lifetime — so instrumentation/APM agents like `dd-trace` can instrument subsequent module loads. Bare specifiers resolve against installed components' `node_modules`; absolute paths are also accepted.

## Companion PR

Core implementation: HarperFast/harper#1569.

## Notes for the reviewer

- Tagged `<VersionBadge version="v5.2.0" />` on the assumption this ships in core v5.2.0 (main is currently on 5.1.15). **Please adjust the version if it lands in a different release.**

_Generated with assistance from Claude (Opus 4.8); reviewed and committed by Kris._
