### PR TITLE
docs(static-files): document before/after handler ordering

### DIFF
--- a/reference/static-files/overview.md
+++ b/reference/static-files/overview.md
@@ -85,7 +85,7 @@ In addition to the standard `files`, `urlPath`, and `timeout` options, `static` 
 
 By default, `static` handles GET requests **before** authentication — and therefore before the [REST](../rest/overview.md) handler, which runs after authentication. This keeps plain file requests fast, and with the default `fallthrough: true` it is invisible: requests that do not match a file simply pass to the next handler.
 
-It matters as soon as you set `fallthrough: false`: the static handler then answers every unmatched GET itself — including GETs for your exported REST resources, which never get a chance to run. Harper logs a startup warning when it detects this combination.
+It matters as soon as you set `fallthrough: false`: the static handler then responds to every unmatched GET itself — including GETs for your exported REST resources, which never get a chance to run. Harper logs a startup warning when it detects this combination.
 
 If your application serves both static files and an API, order the static handler after REST:
 
@@ -114,7 +114,7 @@ Ordering is applied when the component loads; changing `before` or `after` in `c
 
 <VersionBadge version="v4.7.0" />
 
-Because `static` uses the Plugin API, it automatically responds to changes without requiring a Harper restart. Adding, removing, or modifying files — or updating `config.yaml` — takes effect immediately.
+Because `static` uses the Plugin API, it automatically responds to changes without requiring a Harper restart. Adding, removing, or modifying files — or updating `config.yaml` — takes effect immediately. The one exception is [handler ordering](#handler-ordering): changing `before` or `after` automatically restarts the component to rebuild the middleware chain, rather than taking effect in place.
 
 ## Examples
 
@@ -192,7 +192,7 @@ A request to `/non-existent` returns the contents of `static/404.html` with a `4
 
 ### SPA client-side routing
 
-For SPAs that handle routing in the browser with the History API, return the main application file for any path that neither the API nor the file set matches:
+For SPAs that handle routing in the browser with the History API, return the main application file for any path that does not match an API route or a static file:
 
 ```yaml
 rest: true
@@ -206,7 +206,7 @@ static:
     statusCode: 200
 ```
 
-A request to any unmatched path returns `static/index.html` with a `200` status code, allowing the client-side router to handle navigation. The `after: 'rest'` ordering (added in v5.2.0) lets REST resources answer first; without it, the fallback would intercept API GETs too — see [Handler Ordering](#handler-ordering).
+A request to any unmatched path returns `static/index.html` with a `200` status code, allowing the client-side router to handle navigation. The `after: 'rest'` ordering (added in v5.2.0) allows REST resources to be matched first; without it, the fallback would intercept API GETs too — see [Handler Ordering](#handler-ordering).
 
 Alternatively, SPAs that use hash-based routing (e.g. React Router's `createHashRouter` or Vue Router's `createWebHashHistory`) need no fallback at all: every page loads from `/`, which also keeps `index.html` cacheable at a single URL. This works on every Harper version.
 

--- a/reference/static-files/overview.md
+++ b/reference/static-files/overview.md
@@ -110,7 +110,7 @@ GET /app/settings   -> 200 text/html          (index.html - client-side route)
 
 Note the tradeoff: `after: 'rest'` runs the static handler after authentication, so every static-asset request now incurs the credential parsing that the default ordering skips. This is worth it when you serve an API alongside your files, but for an app serving a high volume of assets, choose it deliberately rather than as a free fix.
 
-> **Note:** Handler names are case-sensitive and must match the registered lowercase config key — use `rest`, not the legacy `REST` alias. An unrecognized name such as `after: 'REST'` matches nothing and only logs a warning, leaving the default ordering in place.
+> **Note:** Handler names are case-sensitive and must match the registered config key — use `rest`, not the legacy `REST` alias. Watch for typos: setting `after` (or `before`) to any value suppresses the default `before: 'authentication'` hoist, so if the name matches no registered handler the constraint is ignored (Harper logs a warning) and the handler falls back to registration order — **not** its default pre-authentication position. In other words, `after: 'REST'` behaves like neither the working `after: 'rest'` nor the default.
 
 Ordering is applied when the component loads; changing `before` or `after` in `config.yaml` automatically restarts the component so the new ordering takes effect.
 

--- a/reference/static-files/overview.md
+++ b/reference/static-files/overview.md
@@ -108,6 +108,10 @@ GET /assets/app.js  -> 200 text/javascript    (static file)
 GET /app/settings   -> 200 text/html          (index.html - client-side route)
 ```
 
+Note the tradeoff: `after: 'rest'` runs the static handler after authentication, so every static-asset request now incurs the credential parsing that the default ordering skips. This is worth it when you serve an API alongside your files, but for an app serving a high volume of assets, choose it deliberately rather than as a free fix.
+
+> **Note:** Handler names are case-sensitive and must match the registered lowercase config key — use `rest`, not the legacy `REST` alias. An unrecognized name such as `after: 'REST'` matches nothing and only logs a warning, leaving the default ordering in place.
+
 Ordering is applied when the component loads; changing `before` or `after` in `config.yaml` automatically restarts the component so the new ordering takes effect.
 
 ## Auto-Updates

--- a/reference/static-files/overview.md
+++ b/reference/static-files/overview.md
@@ -108,7 +108,7 @@ GET /assets/app.js  -> 200 text/javascript    (static file)
 GET /app/settings   -> 200 text/html          (index.html - client-side route)
 ```
 
-Ordering is applied when the component loads; changing `before` or `after` requires a restart.
+Ordering is applied when the component loads; changing `before` or `after` in `config.yaml` automatically restarts the component so the new ordering takes effect.
 
 ## Auto-Updates
 

--- a/reference/static-files/overview.md
+++ b/reference/static-files/overview.md
@@ -13,6 +13,7 @@ title: Static Files
 
 - Added in: v4.5.0
 - Changed in: v4.7.0 - (Migrated to Plugin API and new options added)
+- Changed in: v5.2.0 - (`before` / `after` handler ordering options)
 
 The `static` built-in plugin serves static files from your Harper application over HTTP. Use it to host websites, SPAs, downloadable assets, or any static content alongside your Harper data and API endpoints.
 
@@ -72,7 +73,42 @@ In addition to the standard `files`, `urlPath`, and `timeout` options, `static` 
 
 - **`fallthrough`** - `boolean` - _optional_ - If `true`, passes the request to the next handler when the requested file is not found. Set to `false` when using `notFound` to customize 404 responses. Defaults to `true`.
 
-- **`notFound`** - `string | { file: string; statusCode: number }` - _optional_ - A custom file (or file + status code) to return when a path is not found. Useful for serving a custom 404 page or for SPAs that use client-side routing.
+- **`notFound`** - `string | { file: string; statusCode: number }` - _optional_ - A custom file (or file + status code) to return when a path is not found. Useful for serving a custom 404 page or for SPAs that use client-side routing. See [Handler Ordering](#handler-ordering) — combine with `after: 'rest'` if your application also serves an API.
+
+- **`before`** - `string | false` - _optional_ - <VersionBadge version="v5.2.0" /> Run this handler before the named handler in the HTTP middleware chain. Defaults to `'authentication'` so plain file requests skip credential parsing. Set to `false` to clear the default without adding a new constraint (registration order applies).
+
+- **`after`** - `string` - _optional_ - <VersionBadge version="v5.2.0" /> Run this handler after the named handler, e.g. `after: 'rest'` to let REST resources match before static fallbacks. Setting `after` overrides the default `before: 'authentication'`.
+
+## Handler Ordering
+
+<VersionBadge version="v5.2.0" />
+
+By default, `static` handles GET requests **before** authentication — and therefore before the [REST](../rest/overview.md) handler, which runs after authentication. This keeps plain file requests fast, and with the default `fallthrough: true` it is invisible: requests that do not match a file simply pass to the next handler.
+
+It matters as soon as you set `fallthrough: false`: the static handler then answers every unmatched GET itself — including GETs for your exported REST resources, which never get a chance to run. Harper logs a startup warning when it detects this combination.
+
+If your application serves both static files and an API, order the static handler after REST:
+
+```yaml
+rest: true
+
+static:
+  files: 'dist/**'
+  # Let the REST handler match first; only unmatched URLs get the fallback.
+  after: 'rest'
+  notFound:
+    file: 'dist/index.html'
+    statusCode: 200
+  fallthrough: false
+```
+
+```
+GET /Dog/1          -> 200 application/json   (REST resource)
+GET /assets/app.js  -> 200 text/javascript    (static file)
+GET /app/settings   -> 200 text/html          (index.html - client-side route)
+```
+
+Ordering is applied when the component loads; changing `before` or `after` requires a restart.
 
 ## Auto-Updates
 
@@ -152,22 +188,27 @@ static:
 
 A request to `/non-existent` returns the contents of `static/404.html` with a `404` status code.
 
-> **Note:** When using `notFound`, set `fallthrough: false` so the request does not pass through to another handler before the custom 404 response is returned.
+> **Note:** When using `notFound`, set `fallthrough: false` so the request does not pass through to another handler before the custom 404 response is returned. If the application also serves an API, add `after: 'rest'` — see [Handler Ordering](#handler-ordering).
 
 ### SPA client-side routing
 
-For SPAs that handle routing in the browser, return the main application file for any unmatched path:
+For SPAs that handle routing in the browser with the History API, return the main application file for any path that neither the API nor the file set matches:
 
 ```yaml
+rest: true
+
 static:
   files: 'static/**'
+  after: 'rest'
   fallthrough: false
   notFound:
     file: 'static/index.html'
     statusCode: 200
 ```
 
-A request to any unmatched path returns `static/index.html` with a `200` status code, allowing the client-side router to handle navigation.
+A request to any unmatched path returns `static/index.html` with a `200` status code, allowing the client-side router to handle navigation. The `after: 'rest'` ordering (added in v5.2.0) lets REST resources answer first; without it, the fallback would intercept API GETs too — see [Handler Ordering](#handler-ordering).
+
+Alternatively, SPAs that use hash-based routing (e.g. React Router's `createHashRouter` or Vue Router's `createWebHashHistory`) need no fallback at all: every page loads from `/`, which also keeps `index.html` cacheable at a single URL. This works on every Harper version.
 
 ## Dynamic Applications
 


### PR DESCRIPTION
> **Draft** until [HarperFast/harper#1574](https://github.com/HarperFast/harper/pull/1574) merges and its release version is confirmed — the `v5.2.0` badges and changelog line in this page assume the next feature release; adjust if it ships under a different version.

## What

Documents the static plugin's `before` / `after` handler-ordering options added in [HarperFast/harper#1574](https://github.com/HarperFast/harper/pull/1574), and fixes the SPA client-side routing example, which currently documents a config that breaks REST.

## Why

The static handler runs before authentication — and therefore before the REST handler — by default. The existing "SPA client-side routing" example (`notFound` + `fallthrough: false`) therefore answers **every** unmatched GET with index.html, including GETs for exported REST resources: the application's API silently becomes unreachable over GET. This bit the create-harper SPA templates, fixed in [HarperFast/create-harper#109](https://github.com/HarperFast/create-harper/pull/109).

With harper#1574 in place, one line makes the recipe work as readers assume it does:

```yaml
rest: true

static:
  files: 'dist/**'
  after: 'rest' # let REST match first; only unmatched URLs get the fallback
  notFound:
    file: 'dist/index.html'
    statusCode: 200
  fallthrough: false
```

## Changes to `reference/static-files/overview.md`

- New **Handler Ordering** section: default position in the middleware chain, why it exists (file requests skip credential parsing), the `fallthrough: false` trap, the `after: 'rest'` recipe with request mappings, and the new startup warning.
- `before` and `after` added to **Additional Options** (with `v5.2.0` badges), including `before: false` to clear the default constraint.
- **SPA client-side routing** example corrected to include `after: 'rest'`, with a note about pre-5.2 behavior and a pointer to hash-based routing as the version-independent alternative (also keeps index.html cacheable at a single URL).
- **Custom 404 page** example notes when `after: 'rest'` is needed.

## Verification

- `npm run format:check` clean; `npm run build` succeeds (the one broken-anchor warning is pre-existing in `release-notes/v5-lincoln/5.1`, unrelated to this page).
- The behavior described was verified end-to-end against a built harper#1574 dist: with `after: 'rest'`, REST resources return JSON while unmatched deep links receive the index.html fallback.

Related: [HarperFast/harper#1574](https://github.com/HarperFast/harper/pull/1574) - [HarperFast/create-harper#109](https://github.com/HarperFast/create-harper/pull/109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)