### PR TITLE
Document loadedFromSource cache disposition on the request context

### DIFF
--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -264,7 +264,7 @@ Within a resource method, the same value is available on the active context via 
 - `false` — the record was served from the cache: fresh hits, `onlyIfCached` requests, stale-while-revalidate responses (the source fetch continues in the background), and requests that waited on another request's in-flight fetch of the same record. This last case means a cache hit can still take as long as an upstream fetch.
 - Each get on a caching table in the same context overwrites the value, so read it after the `get` you are measuring.
 
-Resource instances also expose this as [`wasLoadedFromSource()`](#wasloadedfromsource-boolean). Prior to Harper 5.1.16, the flag was only observable via an explicitly passed `RequestTarget`; `context.loadedFromSource` was never assigned.
+Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; read it from the context (or an explicitly passed `RequestTarget`). Prior to Harper 5.1.16, the flag was only observable via an explicitly passed `RequestTarget`; `context.loadedFromSource` was never assigned.
 
 #### Source `get` — controlling timestamp and expiration
 

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -255,12 +255,12 @@ Each `get` on a caching table records whether the record came from the cache or 
 ```javascript
 const context = {};
 const record = await MyCache.get(recordId, context);
-console.log(context.loadedFromSource); // true = fetched from source, false = served from cache
+console.log(context.loadedFromSource); // true = went to the source, false = served from cache
 ```
 
 Within a resource method, the same value is available on the active context via `getContext().loadedFromSource` after the `get` resolves. The flag settles as follows:
 
-- `true` — the get fetched the record from the source, including when a source error fell back to a stale record (`staleIfError`).
+- `true` — the get went to the source: either it fetched the record, or the source errored and a stale cached record was served as a fallback (`staleIfError`). `true` means a source request was made, not necessarily that the returned data is fresh.
 - `false` — the record was served from the cache: fresh hits, `onlyIfCached` requests, stale-while-revalidate responses (the source fetch continues in the background), and requests that waited on another request's in-flight fetch of the same record. This last case means a cache hit can still take as long as an upstream fetch.
 - Each get on a caching table in the same context overwrites the value, so read it after the `get` you are measuring.
 
@@ -659,7 +659,7 @@ Returns the current context, which includes:
 
 - `user` — User object with username, role, and authorization information
 - `transaction` — The current transaction
-- `loadedFromSource` — For caching tables, cache disposition of the most recent `get` in this context: `true` if it fetched from the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
+- `loadedFromSource` — For caching tables (5.1.16+), cache disposition of the most recent `get` in this context: `true` if it went to the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
 
 When triggered by HTTP, the context is the `Request` object with these additional properties:
 
@@ -1165,7 +1165,7 @@ getContext is availabe as export from the `harper` module, or as a global variab
 
 - `user` — User object with username, role, and authorization information
 - `transaction` — The current transaction
-- `loadedFromSource` — For caching tables, cache disposition of the most recent `get` in this context: `true` if it fetched from the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
+- `loadedFromSource` — For caching tables (5.1.16+), cache disposition of the most recent `get` in this context: `true` if it went to the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
 
 When triggered by HTTP, the context is the `Request` object with these additional properties:
 

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -264,7 +264,7 @@ Within a resource method, the same value is available on the active context via 
 - `false` — the record was served from the cache: fresh hits, `onlyIfCached` requests, stale-while-revalidate responses (the source fetch continues in the background), and requests that waited on another request's in-flight fetch of the same record. This last case means a cache hit can still take as long as an upstream fetch.
 - Each get on a caching table in the same context overwrites the value, so read it after the `get` you are measuring.
 
-Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; read it from the context (or an explicitly passed `RequestTarget`). In custom resource methods, where `this` is the loaded resource instance, the same value is available as [`this.wasLoadedFromSource()`](#wasloadedfromsource-boolean) (5.1.16+). Prior to Harper 5.1.16, the flag was only observable via an explicitly passed `RequestTarget`; `context.loadedFromSource` was never assigned and `wasLoadedFromSource()` always returned `undefined`.
+Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; read it from the context (or an explicitly passed `RequestTarget`). Prior to Harper 5.1.16, `context.loadedFromSource` was never assigned and the flag was only observable via an explicitly passed `RequestTarget`.
 
 #### Source `get` — controlling timestamp and expiration
 
@@ -428,12 +428,6 @@ class BlogSource extends Resource {
 }
 Post.sourcedFrom(BlogSource);
 ```
-
----
-
-### `wasLoadedFromSource(): boolean`
-
-For caching tables (5.1.16+), reports whether this resource's record was loaded from the source — the same settled semantics as [`context.loadedFromSource`](#observing-cache-disposition). Returns `undefined` until a load resolves, on tables without a source `get`, and on all Harper versions before 5.1.16 (the method previously existed but was never assigned a value).
 
 ---
 

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -264,7 +264,7 @@ Within a resource method, the same value is available on the active context via 
 - `false` — the record was served from the cache: fresh hits, `onlyIfCached` requests, stale-while-revalidate responses (the source fetch continues in the background), and requests that waited on another request's in-flight fetch of the same record. This last case means a cache hit can still take as long as an upstream fetch.
 - Each get on a caching table in the same context overwrites the value, so read it after the `get` you are measuring.
 
-Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; read it from the context (or an explicitly passed `RequestTarget`). Prior to Harper 5.1.16, the flag was only observable via an explicitly passed `RequestTarget`; `context.loadedFromSource` was never assigned.
+Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; read it from the context (or an explicitly passed `RequestTarget`). In custom resource methods, where `this` is the loaded resource instance, the same value is available as [`this.wasLoadedFromSource()`](#wasloadedfromsource-boolean) (5.1.16+). Prior to Harper 5.1.16, the flag was only observable via an explicitly passed `RequestTarget`; `context.loadedFromSource` was never assigned and `wasLoadedFromSource()` always returned `undefined`.
 
 #### Source `get` — controlling timestamp and expiration
 
@@ -433,7 +433,7 @@ Post.sourcedFrom(BlogSource);
 
 ### `wasLoadedFromSource(): boolean`
 
-For caching tables, indicates that this request was a cache miss and the data was loaded from the source resource.
+For caching tables (5.1.16+), reports whether this resource's record was loaded from the source — the same settled semantics as [`context.loadedFromSource`](#observing-cache-disposition). Returns `undefined` until a load resolves, on tables without a source `get`, and on all Harper versions before 5.1.16 (the method previously existed but was never assigned a value).
 
 ---
 

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -248,6 +248,24 @@ Options (all optional; prefer setting these via `@table` schema directives):
 
 Harper automatically serializes concurrent requests for the same missing or stale record — all waiting requests share a single upstream fetch, preventing cache stampedes.
 
+#### Observing cache disposition
+
+Each `get` on a caching table records whether the record came from the cache or from the source, in the `loadedFromSource` property of both the request context and the `RequestTarget`:
+
+```javascript
+const context = {};
+const record = await MyCache.get(recordId, context);
+console.log(context.loadedFromSource); // true = fetched from source, false = served from cache
+```
+
+Within a resource method, the same value is available on the active context via `getContext().loadedFromSource` after the `get` resolves. The flag settles as follows:
+
+- `true` — the get fetched the record from the source, including when a source error fell back to a stale record (`staleIfError`).
+- `false` — the record was served from the cache: fresh hits, `onlyIfCached` requests, stale-while-revalidate responses (the source fetch continues in the background), and requests that waited on another request's in-flight fetch of the same record. This last case means a cache hit can still take as long as an upstream fetch.
+- Each get on a caching table in the same context overwrites the value, so read it after the `get` you are measuring.
+
+Resource instances also expose this as [`wasLoadedFromSource()`](#wasloadedfromsource-boolean). Prior to Harper 5.1.16, the flag was only observable via an explicitly passed `RequestTarget`; `context.loadedFromSource` was never assigned.
+
 #### Source `get` — controlling timestamp and expiration
 
 Inside a source `get()` method, the context (`this.getContext()`) exposes caching-specific properties:
@@ -641,6 +659,7 @@ Returns the current context, which includes:
 
 - `user` — User object with username, role, and authorization information
 - `transaction` — The current transaction
+- `loadedFromSource` — For caching tables, cache disposition of the most recent `get` in this context: `true` if it fetched from the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
 
 When triggered by HTTP, the context is the `Request` object with these additional properties:
 
@@ -1146,6 +1165,7 @@ getContext is availabe as export from the `harper` module, or as a global variab
 
 - `user` — User object with username, role, and authorization information
 - `transaction` — The current transaction
+- `loadedFromSource` — For caching tables, cache disposition of the most recent `get` in this context: `true` if it fetched from the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
 
 When triggered by HTTP, the context is the `Request` object with these additional properties:
 


### PR DESCRIPTION
Companion docs for HarperFast/harper#1575 (fixes HarperFast/harper#1571), which makes cache disposition observable on caching-table gets via `context.loadedFromSource` / `target.loadedFromSource`.

## Changes

- New **Observing cache disposition** subsection under `sourcedFrom()` in `reference/resources/resource-api.md`, documenting the settled semantics verified in the fix: `true` when the get went to the source (including `staleIfError` fallbacks to stale data); `false` for cache hits, `onlyIfCached`, stale-while-revalidate responses, and dedupe-join waits (with the note that such a "hit" can still take as long as the upstream fetch); last get in a context wins.
- `loadedFromSource` listed in both `getContext(): Context` property references (version-gated "5.1.16+"), cross-linked to the new subsection.
- Per the decision on HarperFast/harper#1577 (closed), `wasLoadedFromSource()` is **not** implemented and its reference section is removed (commit 0862bda by @kriszyp) — the context/target API is the single supported way to observe disposition.

## Note for review

The text says "5.1.16" on the assumption harper#1575 ships in the next 5.1 patch. **Hold merging until harper#1575 lands** and confirm the actual patch version then.

_Generated by an LLM (Claude Fable 5), cross-reviewed by Codex and Gemini; all findings addressed. Includes a commit from @kriszyp._