### PR TITLE
docs(configuration): document replication.blobSendDrainTimeout

### DIFF
--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -204,6 +204,7 @@ replication:
 - `securePort` — Secure replication port; _Default_: `9933` (changed from `9925` in v4.5.0)
 - `enableRootCAs` — Verify against Node.js Mozilla CA store; _Default_: `true`
 - `blobTimeout` — Blob transfer timeout (ms); _Default_: `120000`
+- `blobSendDrainTimeout` — Maximum time (ms) a worker waits for in-flight replication blob **sends** to finish before shutting down during a restart, so a rolling restart (e.g., a component deploy reload) doesn't interrupt a transfer in progress. Only sends that are still making progress are waited on; `0` disables draining; _Default_: `600000`
 - `failOver` — Failover to alternate node if peer unreachable; _Default_: `true`
 - `shard` — Shard ID for traffic routing; see [Sharding](../replication/sharding.md)
 - `mtls.certificateVerification` — Certificate revocation checking (CRL/OCSP) for replication connections; see [Certificate Verification](../security/certificate-verification.md)


### PR DESCRIPTION
## Summary

Documents the new `replication.blobSendDrainTimeout` config option in the v5 configuration reference.

Companion to:
- HarperFast/harper#1621 (core: shutdown-drain hook)
- HarperFast/harper-pro#529 (replication: drain in-flight blob sends before worker shutdown)

The option bounds how long a worker waits for in-flight replication blob **sends** to finish before shutting down during a restart (default 10 min; `0` disables), so a rolling restart / component deploy reload doesn't interrupt a transfer and leave the peer's copy diverged.

_Generated by Claude (Opus 4.8)._