### PR TITLE
Correct cache-disposition docs to target.loadedFromSource only (harper#1575 reverted)

### DIFF
--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -250,21 +250,23 @@ Harper automatically serializes concurrent requests for the same missing or stal
 
 #### Observing cache disposition
 
-Each `get` on a caching table records whether the record came from the cache or from the source, in the `loadedFromSource` property of both the request context and the `RequestTarget`:
+Each `get` on a caching table records whether the record came from the cache or from the source in the `loadedFromSource` property of the **`RequestTarget`** for that get. Cache disposition is a per-get result, so it lives on the per-get target — pass an explicit `RequestTarget` to observe it:
 
 ```javascript
-const context = {};
-const record = await MyCache.get(recordId, context);
-console.log(context.loadedFromSource); // true = went to the source, false = served from cache
+import { RequestTarget } from 'harper';
+
+const target = new RequestTarget();
+target.id = recordId;
+const record = await MyCache.get(target);
+console.log(target.loadedFromSource); // true = went to the source, false = served from cache
 ```
 
-Within a resource method, the same value is available on the active context via `getContext().loadedFromSource` after the `get` resolves. The flag settles as follows:
+The flag settles as follows:
 
 - `true` — the get went to the source: either it fetched the record, or the source errored and a stale cached record was served as a fallback (`staleIfError`). `true` means a source request was made, not necessarily that the returned data is fresh.
 - `false` — the record was served from the cache: fresh hits, `onlyIfCached` requests, stale-while-revalidate responses (the source fetch continues in the background), and requests that waited on another request's in-flight fetch of the same record. This last case means a cache hit can still take as long as an upstream fetch.
-- Each get on a caching table in the same context overwrites the value, so read it after the `get` you are measuring.
 
-Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; read it from the context (or an explicitly passed `RequestTarget`). Prior to Harper 5.1.16, `context.loadedFromSource` was never assigned and the flag was only observable via an explicitly passed `RequestTarget`.
+Note that `get()` returns a plain `RecordObject`, not a resource instance — the record itself does not carry cache disposition; the explicitly passed `RequestTarget` is the supported way to observe it. There is deliberately no request-`Context` mirror of this flag: a context is shared across every `get` in the request (including a caching table's internal gets), so a context-level value would be silently overwritten before the caller could read it.
 
 #### Source `get` — controlling timestamp and expiration
 
@@ -653,7 +655,6 @@ Returns the current context, which includes:
 
 - `user` — User object with username, role, and authorization information
 - `transaction` — The current transaction
-- `loadedFromSource` — For caching tables (5.1.16+), cache disposition of the most recent `get` in this context: `true` if it went to the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
 
 When triggered by HTTP, the context is the `Request` object with these additional properties:
 
@@ -1159,7 +1160,6 @@ getContext is availabe as export from the `harper` module, or as a global variab
 
 - `user` — User object with username, role, and authorization information
 - `transaction` — The current transaction
-- `loadedFromSource` — For caching tables (5.1.16+), cache disposition of the most recent `get` in this context: `true` if it went to the source, `false` if served from cache (see [Observing cache disposition](#observing-cache-disposition))
 
 When triggered by HTTP, the context is the `Request` object with these additional properties:
 


### PR DESCRIPTION
The live docs (merged #563) document `context.loadedFromSource` / `getContext().loadedFromSource` with "5.1.16+" badges — but harper#1575 was **reverted** on v5.1 before v5.1.17 shipped (the context mirror is last-write-wins when a resource's own `get` triggers internal caching gets), so that API exists in no current release. harper#1626 carries the target-only end-state to main.

## Changes to `reference/resources/resource-api.md`

- **Observing cache disposition** section rewritten to the explicit-`RequestTarget` pattern (the supported way in all 5.1.x releases and in #1626's end-state), with a note explaining *why* there is deliberately no Context mirror.
- Removed the two `getContext()` list entries for `loadedFromSource` (context is never assigned).
- Removed the "5.1.16+" version claims.

The flag-semantics bullets (`true`/`false` meanings, staleIfError, dedupe-join) are kept verbatim — kriszyp verified those in #563.

## Note for review

This describes current 5.1.x behavior. If harper#1626 (adds `Age` header on cache hits + hit-marking on the `loadAsInstance=false` path) merges before this does, the section may deserve a follow-up for 5.2 semantics — flagging rather than pre-documenting unmerged behavior.

_Generated by an LLM (Claude Fable 5)._