### PR TITLE
Correct custom mcpTools auth wording: anonymously invocable, no login gate

### DIFF
--- a/reference/mcp/tools-and-resources.md
+++ b/reference/mcp/tools-and-resources.md
@@ -106,7 +106,9 @@ class Orders extends Tables.orders {
 }
 ```
 
-The corresponding instance method runs through Harper's normal `transactional()` envelope, so per-record `allow*` predicates and audit logging behave the same way as regular verb dispatch. Authentication is "is the user logged in" only — finer-grained gating is the method's responsibility.
+The corresponding instance method runs through Harper's normal `transactional()` envelope, so per-record `allow*` predicates and audit logging behave the same way as regular verb dispatch.
+
+**Custom tools are exposed to any MCP session — including anonymous, unauthenticated ones.** Unlike the auto-generated verb tools (which are RBAC-filtered per user at `tools/list` time and enforce table permissions on call), the MCP layer performs no authentication or ACL check for a custom tool: it is listed to every session and its method executes even when no user is logged in (`context.user` may be empty). Access control is entirely the method's responsibility — to restrict a tool to authenticated users or specific roles, check `context.user` (or rely on the per-record `allow*` predicates its data access triggers) inside the method and throw when the caller doesn't qualify.
 
 ### `exportTypes` gating
 


### PR DESCRIPTION
Fixes #566.

The Custom `mcpTools` section claimed "Authentication is \"is the user logged in\" only" — inaccurate: custom tools register with `visibleTo: () => true`, the MCP route mounts with no auth requirement, and an anonymous session can list and call them (verified live by the reporter on 5.1.15, and consistent with the anonymous-session posture verified during harper#1613/#1633). The paragraph now states the anonymous exposure plainly, contrasts it with the RBAC-filtered auto verb tools, and tells authors exactly how to gate (`context.user` check in the method).

Same wording had been copied into the pending mcpResources docs (#567) — corrected there in its own branch.

_Generated by an LLM (Claude Fable 5)._