### PR TITLE
docs(env-vars): clarify loadEnv/.env cannot shape Harper's instance config

### DIFF
--- a/reference/environment-variables/overview.md
+++ b/reference/environment-variables/overview.md
@@ -49,7 +49,9 @@ Because Harper is a single-process application, environment variables are loaded
 :::warning
 `loadEnv` supplies **application** environment variables — values your component code reads from `process.env` (secrets, API endpoints, app settings). It does **not** configure Harper itself.
 
-Harper's own instance-wide configuration is composed once at startup, **before** any component's `loadEnv` runs. As a result, config-shaping variables such as `HARPER_CONFIG`, `HARPER_SET_CONFIG`, and `HARPER_DEFAULT_CONFIG` delivered through a `.env` file are read too late to take effect and are ignored (Harper logs a warning when it detects one). <VersionBadge type="changed" version="v5.2.0" />
+Harper's own instance-wide configuration is composed once at startup, **before** any component's `loadEnv` runs. As a result, config-shaping variables such as `HARPER_CONFIG`, `HARPER_SET_CONFIG`, and `HARPER_DEFAULT_CONFIG` delivered through a `.env` file are read too late to take effect and are ignored (Harper logs a warning when it detects any of them).
+
+<VersionBadge type="changed" version="v5.2.0" />
 
 To change Harper's configuration, set it in the [configuration file](../configuration/overview.md) or export the variable in the real process/container environment **before** Harper starts — not through `loadEnv`.
 :::

--- a/reference/environment-variables/overview.md
+++ b/reference/environment-variables/overview.md
@@ -46,6 +46,14 @@ myApp:
 
 Because Harper is a single-process application, environment variables are loaded onto `process.env` and are shared across all components. As long as `loadEnv` is listed before dependent components, those components will have access to the loaded variables.
 
+:::warning
+`loadEnv` supplies **application** environment variables — values your component code reads from `process.env` (secrets, API endpoints, app settings). It does **not** configure Harper itself.
+
+Harper's own instance-wide configuration is composed once at startup, **before** any component's `loadEnv` runs. As a result, config-shaping variables such as `HARPER_CONFIG`, `HARPER_SET_CONFIG`, and `HARPER_DEFAULT_CONFIG` delivered through a `.env` file are read too late to take effect and are ignored (Harper logs a warning when it detects one). <VersionBadge type="changed" version="v5.2.0" />
+
+To change Harper's configuration, set it in the [configuration file](../configuration/overview.md) or export the variable in the real process/container environment **before** Harper starts — not through `loadEnv`.
+:::
+
 ## Override Behavior
 
 By default, `loadEnv` follows the standard dotenv convention: **existing environment variables take precedence** over values in `.env` files. This means variables already set in the shell or container environment will not be overwritten.


### PR DESCRIPTION
## Summary

The Environment Variables page documents `loadEnv` / `.env` but doesn't state an important scope boundary that trips users up: **`.env` supplies *application* environment variables, not Harper's own configuration.**

Config-shaping variables (`HARPER_CONFIG`, `HARPER_SET_CONFIG`, `HARPER_DEFAULT_CONFIG`) delivered through a `.env` file are read **after** the instance config has already been composed, so they're ignored. Harper now logs a warning when it detects one, rather than silently no-op'ing. This adds a `:::warning` admonition to `reference/environment-variables/overview.md` documenting that behavior and pointing users to the config file / real process env as the correct mechanism.

Documents the warn-don't-honor behavior shipped in [harper#1513](https://github.com/HarperFast/harper/issues/1513) (fix PR #1580).

## Where to look
- One-paragraph warning admonition added after the "Load Order" section.
- `<VersionBadge type="changed" version="v5.2.0" />` — **please confirm the exact release** #1580 ships in (main is currently `5.2.0-alpha`, so v5.2.0 is my best estimate; adjust if it lands in a 5.1.x patch).

Surfaced by exploratory QA while regression-verifying #1513. 🤖 Generated by an LLM (KrAIs / Claude Opus 4.8).