### PR TITLE
fix: correct two example bugs caught by skills#70's review

### DIFF
--- a/reference/rest/querying.md
+++ b/reference/rest/querying.md
@@ -225,7 +225,7 @@ type Product @table @export {
 	id: Long @primaryKey
 	name: String
 	resellerIds: [Long] @indexed
-	resellers: [Reseller] @relationship(from: "resellerId")
+	resellers: [Reseller] @relationship(from: "resellerIds")
 }
 ```
 

--- a/release-notes/v5-lincoln/v5-migration.md
+++ b/release-notes/v5-lincoln/v5-migration.md
@@ -73,7 +73,7 @@ class MyResource {
 		// this function is within a transaction, with a consistent snapshot of data that won't change, but previous code could
 		// call Table.get without a context, it would not use the current transaction and would instead get the latest data
 		while ((await Table.get(target)).status !== 'ready') {
-			delay(100);
+			await delay(100);
 		}
 		return Table.get(target);
 	}
@@ -93,7 +93,7 @@ class MyResource {
 		// now we can call Table.get and it will read the latest data.
 		// we could also explicitly start a new transaction here for each get:
 		while ((await transaction(() => Table.get(target))).status !== 'ready') {
-			delay(100);
+			await delay(100);
 		}
 		return Table.get(target);
 	}


### PR DESCRIPTION
## Summary
- `release-notes/v5-lincoln/v5-migration.md`: the polling-loop example was missing `await` on `delay(100)` — since `delay` is imported from `node:timers/promises`, the un-awaited call turned the intended ~10Hz poll into a tight loop that hammers `Table.get` as fast as the read path allows.
- `reference/rest/querying.md`: the `resellers` relationship example pointed `from` at the singular `resellerId`, which the schema never declares — the indexed field is plural `resellerIds`. A relationship built from this example can't resolve its foreign key.

Both found by a cross-model (Codex) review on [HarperFast/skills#70](https://github.com/HarperFast/skills/pull/70), which regenerates its rules from this repo — this PR fixes the source so a future regen picks up the correction.

A third finding from that review — recommending `allowReadRecord` over `allowRead` for record-scoped authorization in the vector-indexing guide — was **not** applied: `allowReadRecord` doesn't exist in Harper's actual codebase, and a synchronous `allowRead` override already is the correct record-scoped hook (confirmed against `resources/Resource.ts`). That doc example was correct as written.

## Test plan
- [x] Diffed against the exact commit skills#70 was regenerated from (`c5be2f9`) to confirm both fixes land in the right source location.
- [x] Verified `delay` is a real `node:timers/promises` import (returns a Promise) in both affected code blocks.
- [x] Verified the schema block only declares `resellerIds` (plural), confirming `resellerId` in the relationship directive was a typo, not an intentional alias.
- Docs-only change; no build/test suite applicable beyond the above manual verification.
