### PR TITLE
Document get_deployment_payload / delete_deployment_payload response contracts

### DIFF
--- a/reference/operations-api/operations.md
+++ b/reference/operations-api/operations.md
@@ -697,9 +697,11 @@ Returns the raw tarball for a deployment. Useful for inspecting or re-deploying 
 }
 ```
 
+The response is the raw tarball bytes (`Content-Type: application/octet-stream`, with a `Content-Disposition` download filename) - not JSON and not base64-encoded, so payloads of any size stream without inflation. Returns `404` if the deployment does not exist or its payload has already been reclaimed (by payload retention or `delete_deployment_payload`).
+
 ### `delete_deployment_payload`
 
-Removes the tarball blob from a deployment record. The deployment record itself is retained; only the binary payload is deleted. Use this to reclaim storage after confirming a deployment is stable.
+Removes the tarball blob from a deployment record. The deployment record itself is retained; only the binary payload is deleted. Use this to reclaim storage after confirming a deployment is stable. The deletion replicates, so one call frees the payload's storage on every node in the cluster.
 
 ```json
 {
@@ -707,6 +709,18 @@ Removes the tarball blob from a deployment record. The deployment record itself 
 	"deployment_id": "a3f8c2d1..."
 }
 ```
+
+Response:
+
+```json
+{
+	"message": "Deleted payload for deployment 'a3f8c2d1...'",
+	"deployment_id": "a3f8c2d1...",
+	"freed_bytes": 52428800
+}
+```
+
+The deployment must be in a terminal status (`success`, `failed`, or `rolled_back`); deleting the payload of an in-progress deployment fails with `409`, since its payload may still be replicating to peers. Deleting an already-reclaimed payload succeeds with `freed_bytes: 0` (the operation is idempotent). A `payload_dropped` entry recording the deleting user is appended to the deployment's `event_log`.
 
 ### `add_ssh_key`
 

--- a/reference/operations-api/operations.md
+++ b/reference/operations-api/operations.md
@@ -699,6 +699,8 @@ Returns the raw tarball for a deployment. Useful for inspecting or re-deploying 
 
 The response is the raw tarball bytes (`Content-Type: application/octet-stream`, with a `Content-Disposition` download filename) - not JSON and not base64-encoded, so payloads of any size stream without inflation. Returns `404` if the deployment does not exist or its payload has already been reclaimed (by payload retention or `delete_deployment_payload`).
 
+Unlike most other `super_user` operations, this check is enforced directly in the handler and cannot be satisfied by granting the operation through a role's `operations` allowlist - only an actual `super_user` role can call it.
+
 ### `delete_deployment_payload`
 
 Removes the tarball blob from a deployment record. The deployment record itself is retained; only the binary payload is deleted. Use this to reclaim storage after confirming a deployment is stable. The deletion replicates, so one call frees the payload's storage on every node in the cluster.


### PR DESCRIPTION
Companion to [HarperFast/harper#1898 "Implement get_deployment_payload and delete_deployment_payload operations"](https://github.com/HarperFast/harper/pull/1898), which implements the two operations (documented since 5.1 but returning `Operation not found` — [harper#1893](https://github.com/HarperFast/harper/issues/1893)).

Adds the previously-unspecified behavioral contracts:

- `get_deployment_payload` — response is raw tarball bytes (octet-stream + download filename), never JSON/base64; 404 when the payload was reclaimed.
- `delete_deployment_payload` — cluster-wide reclaim note, terminal-status requirement (409 otherwise), idempotency (`freed_bytes: 0`), response shape, and the `payload_dropped` audit event.

Hold merge until harper#1898 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)