### PR TITLE
fix(mcp): correct the exportTypes MCP-gating example

### DIFF
--- a/reference/mcp/tools-and-resources.md
+++ b/reference/mcp/tools-and-resources.md
@@ -112,10 +112,10 @@ The corresponding instance method runs through Harper's normal `transactional()`
 
 ### `exportTypes` gating
 
-The MCP surface mirrors the public REST surface. A Resource is filtered out of MCP enumeration entirely when its registration sets `exportTypes.mcp = false`:
+The MCP surface mirrors the public REST surface. A Resource is filtered out of MCP enumeration entirely when its registration sets `exportTypes.mcp = false`. The `exportTypes` map is supplied to the registration call — `server.resources.set(path, Resource, exportTypes)` — not to `server.http` (which registers HTTP handlers and does not read `exportTypes`), and a `static exportTypes` field on the class is not read either:
 
 ```ts
-server.http(Resource, { name: 'internal-thing', exportTypes: { mcp: false } });
+server.resources.set('internal-thing', Resource, { mcp: false });
 ```
 
 This is independent of the `http` exportType — the only switch that operators set to scope MCP visibility is `mcp`.


### PR DESCRIPTION
## Summary

The `### exportTypes gating` section on the MCP Tools and Resources page documents gating a Resource out of the MCP surface with:

```ts
server.http(Resource, { name: 'internal-thing', exportTypes: { mcp: false } });
```

That call does not gate anything. `server.http` (= `httpServer`, harper `server/http.ts`) registers HTTP handlers and reads `port`/`name`/`before`/`after`/`urlPath`/`host`/`runFirst` — it has **zero** `exportTypes` handling. The `exportTypes` map is consumed by the resource registration call:

```ts
server.resources.set('internal-thing', Resource, { mcp: false });
```

Verified against harper `main`: `Resources.set(path, resource, exportTypes)` (`resources/Resources.ts`) stores it, and the MCP enumerator reads `entry.exportTypes?.mcp` (`components/mcp/resources.ts`). Also added a note that a `static exportTypes` field on the class is not read — a common adjacent mistake.

## Why now

@kriszyp flagged this same pattern in the `harper-mcp` skill review (HarperFast/skills#69), where it was corrected. The `harper-mcp` skill is being flipped to generate its rules from these docs, and `automatic-verb-tools` is the one docs-mapped rule that **can't** flip until this example is fixed — generating from the buggy source would bake the broken call back into the skill. This unblocks that flip.

## Where to look

One example swapped in `reference/mcp/tools-and-resources.md` plus a one-sentence clarification. Prose about the `exportTypes.mcp` concept is unchanged and was already correct.

Cross-links: HarperFast/skills#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)
