### PR TITLE
Fix the v5 migration guide's transaction example

### DIFF
--- a/release-notes/v5-lincoln/v5-migration.md
+++ b/release-notes/v5-lincoln/v5-migration.md
@@ -84,7 +84,7 @@ Now the internal `Table.get` will automatically use the current transaction, whi
 
 ```javascript
 import { setTimeout as delay } from 'node:timers/promises';
-import { getContext } from 'harper';
+import { getContext, transaction } from 'harper';
 class MyResource {
 	static async get(target) {
 		// this function is still within a transaction, with a consistent snapshot of data that won't change, but we should


### PR DESCRIPTION
Adds the missing `transaction` import so the Transactions and Context example is self-contained.

Generated by Codex.