### PR TITLE
fix(ci): use admin-scoped token to delete PR preview environments

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -226,26 +226,29 @@ jobs:
 
       # Deleting an environment requires repository *administration* permission,
       # which can never be granted to the workflow's GITHUB_TOKEN (it is not an
-      # available scope in the `permissions:` block). This step therefore uses
-      # PREVIEW_CLEANUP_TOKEN: a fine-grained PAT (or GitHub App token) scoped to
-      # this repository with "Administration: read and write".
+      # available scope in the `permissions:` block). These steps mint an
+      # installation token for an org-owned GitHub App that has
+      # "Administration: read and write" on this repository. If the App isn't
+      # configured (no PREVIEW_CLEANUP_APP_ID variable), both steps are skipped.
+      - name: Generate environment-cleanup token
+        id: cleanup-token
+        if: ${{ vars.PREVIEW_CLEANUP_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PREVIEW_CLEANUP_APP_ID }}
+          private-key: ${{ secrets.PREVIEW_CLEANUP_APP_PRIVATE_KEY }}
+
       - name: Delete GitHub environment
+        if: ${{ vars.PREVIEW_CLEANUP_APP_ID != '' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PREVIEW_CLEANUP_TOKEN || github.token }}
+          github-token: ${{ steps.cleanup-token.outputs.token }}
           script: |
             const environmentName = `pr-${context.payload.pull_request.number}`;
 
-            try {
-              await github.rest.repos.deleteAnEnvironment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                environment_name: environmentName
-              });
-              console.log(`Deleted environment: ${environmentName}`);
-            } catch (error) {
-              core.warning(
-                `Could not delete environment ${environmentName}: ${error.message}. ` +
-                'Ensure the PREVIEW_CLEANUP_TOKEN secret is set to a token with repository Administration write access.'
-              );
-            }
+            await github.rest.repos.deleteAnEnvironment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment_name: environmentName
+            });
+            console.log(`Deleted environment: ${environmentName}`);

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -192,7 +192,7 @@ jobs:
             restart=true
           echo "Cleaning up preview for PR #${{ github.event.pull_request.number }}"
 
-      - name: Update deployment status and delete environment
+      - name: Update deployment status
         uses: actions/github-script@v8
         with:
           script: |
@@ -216,7 +216,26 @@ jobs:
               });
             }
 
-            // Delete the environment
+            // Add cleanup comment to PR
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `## 🧹 Preview Cleanup\n\nThe preview deployment for this PR has been removed.`
+            });
+
+      # Deleting an environment requires repository *administration* permission,
+      # which can never be granted to the workflow's GITHUB_TOKEN (it is not an
+      # available scope in the `permissions:` block). This step therefore uses
+      # PREVIEW_CLEANUP_TOKEN: a fine-grained PAT (or GitHub App token) scoped to
+      # this repository with "Administration: read and write".
+      - name: Delete GitHub environment
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PREVIEW_CLEANUP_TOKEN || github.token }}
+          script: |
+            const environmentName = `pr-${context.payload.pull_request.number}`;
+
             try {
               await github.rest.repos.deleteAnEnvironment({
                 owner: context.repo.owner,
@@ -225,13 +244,8 @@ jobs:
               });
               console.log(`Deleted environment: ${environmentName}`);
             } catch (error) {
-              console.log(`Could not delete environment ${environmentName}: ${error.message}`);
+              core.warning(
+                `Could not delete environment ${environmentName}: ${error.message}. ` +
+                'Ensure the PREVIEW_CLEANUP_TOKEN secret is set to a token with repository Administration write access.'
+              );
             }
-
-            // Add cleanup comment to PR
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `## 🧹 Preview Cleanup\n\nThe preview deployment for this PR has been removed.`
-            });

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -42,12 +42,17 @@ jobs:
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # checkout v7 blocks fork-PR checkout under pull_request_target by
+          # default. We opt in deliberately: fork PRs are gated behind the
+          # 'preview' environment (see the job's `environment:` above), which
+          # requires manual approval before secrets are exposed.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -66,7 +71,7 @@ jobs:
           npm run build
 
       - name: Upload build artifact for local testing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-${{ github.event.pull_request.number }}-build
           path: build/
@@ -116,7 +121,7 @@ jobs:
       - name: Create deployment
         env:
           HARPER_PREVIEW_TARGET: ${{ secrets.HARPER_PREVIEW_TARGET }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -163,10 +168,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -193,7 +198,7 @@ jobs:
           echo "Cleaning up preview for PR #${{ github.event.pull_request.number }}"
 
       - name: Update deployment status
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -233,14 +238,14 @@ jobs:
       - name: Generate environment-cleanup token
         id: cleanup-token
         if: ${{ vars.PREVIEW_CLEANUP_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.PREVIEW_CLEANUP_APP_ID }}
           private-key: ${{ secrets.PREVIEW_CLEANUP_APP_PRIVATE_KEY }}
 
       - name: Delete GitHub environment
         if: ${{ vars.PREVIEW_CLEANUP_APP_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.cleanup-token.outputs.token }}
           script: |


### PR DESCRIPTION
## Problem

The "Cleanup PR Preview" job has never been able to delete the per-PR GitHub Environments, logging:

> Could not delete environment pr-601: Resource not accessible by integration

This is a hard GitHub limitation, not a permissions-block misconfiguration: `DELETE /repos/{owner}/{repo}/environments/{name}` requires repository **administration** permission, and `administration` is not a grantable scope for the workflow's `GITHUB_TOKEN` — no `permissions:` combination can make the current call succeed. As a result ~120 stale `pr-*` environments had accumulated in Settings → Environments (now purged manually).

## Fix

- Split environment deletion out of the deployment-status step into its own step.
- Mint an installation token for an **org-owned GitHub App** via `actions/create-github-app-token@v2` and use it for the delete call. No PAT tied to a person, no long-lived admin credential stored — the App private key only ever produces short-lived (1 hour) installation tokens scoped to this repo.
- If the App isn't configured yet (`PREVIEW_CLEANUP_APP_ID` variable unset), both steps are skipped — no noisy always-failing fallback. Once configured, a real deletion failure fails the step loudly.
- Deployment-status inactivation and the PR comment still use the default `GITHUB_TOKEN`.

## Required follow-up (org admin)

1. Create a GitHub App **owned by the HarperFast org**: Org Settings → Developer settings → GitHub Apps → New GitHub App. Disable webhooks; grant only Repository permission **Administration: read and write**; "Only on this account".
2. Generate a private key, install the App on the org restricted to `HarperFast/documentation`.
3. In this repo: Actions **variable** `PREVIEW_CLEANUP_APP_ID` = the App ID, Actions **secret** `PREVIEW_CLEANUP_APP_PRIVATE_KEY` = the .pem contents.

Note: the token is only minted in the cleanup job, which checks out and runs base-repo code only — it is never available to the `pull_request_target` build of untrusted PR code.

## Also in this PR: action pinning

All actions are bumped to their latest releases and pinned to full commit SHAs (with `# vX.Y.Z` comments) to guard against tag-rewrite supply-chain attacks: checkout v7.0.1, setup-node v7.0.0, upload-artifact v7.0.1, github-script v9.0.0, create-github-app-token v3.2.0.

Note: checkout v7 now blocks fork-PR checkout under `pull_request_target` by default. Fork previews are intentional here and already gated behind the `preview` environment's manual approval, so the deploy job opts in via `allow-unsafe-pr-checkout: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
