### PR TITLE
ci: pin deploy/validate workflow actions to commit SHAs at latest releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,9 +32,9 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -91,14 +91,14 @@ jobs:
 
       - name: Upload npm logs on failure
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-logs
           path: |
             ~/.npm/_logs/
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build
 
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
   # Notify the skills repo that docs changed, so it can regenerate its
   # docs-driven rules against the just-deployed content. See the

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,8 +27,8 @@ jobs:
           - check: Format Check
             command: format:check
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Bumps every `uses:` action in `deploy.yaml` and `validate.yaml` to its latest release and pins it to the full commit SHA with a `# vX.Y.Z` comment, matching the convention applied to `pr-preview.yaml` in the fix-preview-env-cleanup branch.

| Action | Before | After |
|---|---|---|
| actions/checkout | v6 | `3d3c42e5…` # v7.0.1 |
| actions/setup-node | v6 | `82076278…` # v7.0.0 |
| actions/upload-artifact | v6 | `043fb46d…` # v7.0.1 |
| actions/upload-pages-artifact | v4 | `fc324d35…` # v5.0.0 |
| actions/deploy-pages | v4 | `cd2ce8fc…` # v5.0.0 |

`actions/create-github-app-token` in deploy.yaml was already pinned at the latest release (v3.2.0), so it is unchanged.

## Breaking-change review

- **checkout v7** blocks fork-PR checkout under `pull_request_target`/`workflow_run` unless `allow-unsafe-pr-checkout: true`. Neither workflow is affected: deploy.yaml runs on `push` to main / `workflow_dispatch`, and validate.yaml runs on plain `pull_request`.
- **setup-node v7**, **upload-artifact v7**: ESM migration and dependency bumps; no input changes for our usage.
- **upload-pages-artifact v5** / **deploy-pages v5**: internal upload-artifact v7 and Node 24 updates; no config changes needed. Both bumped together to stay on compatible majors.

All tags/SHAs were resolved via `gh api repos/<owner>/<repo>/releases/latest` and `.../commits/<tag>`; the checkout/setup-node/upload-artifact pins match the SHAs already used in pr-preview.yaml. Both files validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)