### PR TITLE
ci: re-enable the pr-preview paths filter

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -3,26 +3,25 @@ name: Deploy PR Preview
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
-    # Temporarily disable the file filter so we get preview deploys for reference docs migration PRs
-    # paths:
-    #   - 'reference/**'
-    #   - 'reference_versioned_docs/**'
-    #.  - 'reference_versioned_sidebars/**'
-    #   - 'reference_versions.json'
-    #   - 'docs/**'
-    #   - 'fabric/**'
-    #   - 'learn/**'
-    #   - 'release-notes/**'
-    #   - 'src/**'
-    #   - 'static/**'
-    #   - 'versioned_docs/**'
-    #   - 'versioned_sidebars/**'
-    #   - 'docusaurus.config.ts'
-    #   - 'package-lock.json'
-    #   - 'package.json'
-    #   - 'redirects.ts'
-    #   - 'sidebars*.ts'
-    #   - 'versions.json'
+    paths:
+      - 'reference/**'
+      - 'reference_versioned_docs/**'
+      - 'reference_versioned_sidebars/**'
+      - 'reference_versions.json'
+      - 'docs/**'
+      - 'fabric/**'
+      - 'learn/**'
+      - 'release-notes/**'
+      - 'src/**'
+      - 'static/**'
+      - 'versioned_docs/**'
+      - 'versioned_sidebars/**'
+      - 'docusaurus.config.ts'
+      - 'package-lock.json'
+      - 'package.json'
+      - 'redirects.ts'
+      - 'sidebars*.ts'
+      - 'versions.json'
 
 # Cancel previous runs when new commits are pushed to the PR
 concurrency:

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -97,9 +97,9 @@ jobs:
           echo "Contents of $PR_DIR:"
           ls -la "$PR_DIR"
 
-      - name: Install HarperDB CLI
+      - name: Install Harper CLI
         run: |
-          npm install -g harperdb
+          npm install -g harper
 
       - name: Deploy to HarperDB
         env:
@@ -176,9 +176,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 
-      - name: Install HarperDB CLI
+      - name: Install Harper CLI
         run: |
-          npm install -g harperdb
+          npm install -g harper
 
       - name: Remove preview deployment
         env:


### PR DESCRIPTION
Restores the `paths:` filter on the PR preview workflow, which had been commented out ("Temporarily disable the file filter so we get preview deploys for reference docs migration PRs"). The restored filter includes the reference-docs paths (`reference/**`, `reference_versioned_docs/**`, `reference_versioned_sidebars/**`, `reference_versions.json`) alongside the original list, so reference PRs keep their previews while workflow-only or repo-meta PRs (like #610 and #609) stop triggering full preview builds and fabric deploys.

Cleanup symmetry: a PR that never matched the filter never deployed a preview, so its skipped cleanup job on close has nothing to clean — no orphaned environments.

Note this PR itself won't get a preview once merged-into behavior applies to new PRs; that's the intended effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)