### PR TITLE
chore: migrate to @harperfast/code-guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Review `README.md` and `CONTRIBUTING.md` for all relevant repository information
 ## Code Style
 
 - TypeScript (config files and scripts), MDX/Markdown (content).
-- Prettier is configured via `@harperdb/code-guidelines/prettier` (see `package.json`).
+- Prettier is configured via `@harperfast/code-guidelines/prettier` (see `package.json`).
 - **Required before every commit/PR:** run `npm run format:write`, then confirm `npm run format:check` is clean. This is a hard gate, not advisory — CI fails any unformatted PR (see [CI](#ci)).
 - Formatting applies to **every file in the repo**, not just content. Prettier runs against the whole tree (`prettier .`) — `.ts`, `.md`, `.mdx`, `.json`, and files under `plans/`, `scripts/`, etc. Do not assume a directory is exempt because it is not user-facing docs.
 - The lint script is a no-op (`echo 0`); do not expect `npm run lint` to catch issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ npm run format:write
 npm run format:check
 ```
 
-CI runs `npm run format:check` on every pull request and will fail if anything is unformatted. If CI fails on formatting, run `npm run format:write` locally and commit the result. Prettier is configured via `@harperdb/code-guidelines/prettier` (see `package.json`).
+CI runs `npm run format:check` on every pull request and will fail if anything is unformatted. If CI fails on formatting, run `npm run format:write` locally and commit the result. Prettier is configured via `@harperfast/code-guidelines/prettier` (see `package.json`).
 
 ## Site Organization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@docusaurus/tsconfig": "3.9.2",
 				"@docusaurus/types": "3.9.2",
 				"@easyops-cn/docusaurus-search-local": "0.52.3",
-				"@harperdb/code-guidelines": "0.0.6",
+				"@harperfast/code-guidelines": "0.1.1",
 				"@mdx-js/react": "3.1.1",
 				"@signalwire/docusaurus-plugin-llms-txt": "1.2.2",
 				"clsx": "2.1.1",
@@ -4828,10 +4828,10 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@harperdb/code-guidelines/-/code-guidelines-0.0.6.tgz",
-			"integrity": "sha512-fHrhVw17A9gdP0K2J7s/5mP397obG4KFFm6cSGikaUetUU5sFps3/jUj23cexpTkakEOdgGnn5l3Q5TV1eBLCA==",
+		"node_modules/@harperfast/code-guidelines": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/code-guidelines/-/code-guidelines-0.1.1.tgz",
+			"integrity": "sha512-NgYNRfNtbTGm8JFja5sLFzDD9e6WyeYVuGbnvVhp7rw9vRpAMrDYky27n1RkHTwEvnai2j6hQfm4XwmMH89Wvg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@docusaurus/tsconfig": "3.9.2",
 				"@docusaurus/types": "3.9.2",
 				"@easyops-cn/docusaurus-search-local": "0.52.3",
-				"@harperfast/code-guidelines": "0.1.1",
+				"@harperfast/code-guidelines": "0.1.2",
 				"@mdx-js/react": "3.1.1",
 				"@signalwire/docusaurus-plugin-llms-txt": "1.2.2",
 				"clsx": "2.1.1",
@@ -4829,9 +4829,9 @@
 			}
 		},
 		"node_modules/@harperfast/code-guidelines": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/code-guidelines/-/code-guidelines-0.1.1.tgz",
-			"integrity": "sha512-NgYNRfNtbTGm8JFja5sLFzDD9e6WyeYVuGbnvVhp7rw9vRpAMrDYky27n1RkHTwEvnai2j6hQfm4XwmMH89Wvg==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/code-guidelines/-/code-guidelines-0.1.2.tgz",
+			"integrity": "sha512-kMW4OgDRcNttjYvhtjS+5idKQEN6SPTl9n7xNs/x7xRJ4Yr3x2ZdZGlc0U/wH7Bq3C+bKl6Dx65NH0RG6xIl5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@docusaurus/tsconfig": "3.9.2",
 		"@docusaurus/types": "3.9.2",
 		"@easyops-cn/docusaurus-search-local": "0.52.3",
-		"@harperfast/code-guidelines": "0.1.1",
+		"@harperfast/code-guidelines": "0.1.2",
 		"@mdx-js/react": "3.1.1",
 		"@signalwire/docusaurus-plugin-llms-txt": "1.2.2",
 		"clsx": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@docusaurus/tsconfig": "3.9.2",
 		"@docusaurus/types": "3.9.2",
 		"@easyops-cn/docusaurus-search-local": "0.52.3",
-		"@harperdb/code-guidelines": "0.0.6",
+		"@harperfast/code-guidelines": "0.1.1",
 		"@mdx-js/react": "3.1.1",
 		"@signalwire/docusaurus-plugin-llms-txt": "1.2.2",
 		"clsx": "2.1.1",
@@ -58,6 +58,6 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"prettier": "@harperdb/code-guidelines/prettier",
+	"prettier": "@harperfast/code-guidelines/prettier",
 	"license": "Apache-2.0"
 }


### PR DESCRIPTION
`@harperdb/code-guidelines` has been deprecated and republished as `@harperfast/code-guidelines`. Version 0.1.2 is functionally identical to 0.0.6 — no config changes, just the new package name (0.1.2 also adds a `files` allowlist so `.claude` and `docs` are no longer included in the published artifact).

This updates the dependency, any config references (prettier/eslint/docs), and the lockfile. No new lockfiles were added.

<sub>sent with Claude Fable 5</sub>