### PR TITLE
docs: document static loadAsInstance in the v5 Resource API reference

### DIFF
--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -27,22 +27,15 @@ Static methods are defined on a Resource class and are the preferred way to inte
 
 ### `static loadAsInstance?: boolean`
 
-> **You do not need this flag when you override static methods — which is the recommended approach.** `loadAsInstance` is a legacy compatibility flag that only affects how Harper's **built-in** dispatch calls a resource's **instance** methods. It does not change the signature or behavior of a static method you define yourself.
+> **New v5 code does not need this flag.** It is a v4-era compatibility flag that selects between two behavioral modes for a resource's **instance** methods. It has no effect on a static method you define yourself.
 >
-> When you override a static verb (`static get`, `static post`, …), your method _replaces_ the built-in dispatch — including the code that reads `loadAsInstance`. Your static method always receives `(target, data)`, so the flag is irrelevant to it. This is the main reason static methods are the recommended shape for custom endpoints: they sidestep the flag entirely.
+> When you override a static verb (`static get`, `static post`, …), your method _replaces_ Harper's built-in dispatch — including the code that reads `loadAsInstance`. Your static method always receives `(target, data)`, so the flag is irrelevant to it. This is a large part of why static methods are the recommended shape for custom endpoints: they sidestep the flag entirely.
 >
-> Where the flag still matters is the legacy pattern of defining REST-mirroring **instance** methods (instance `get`, `put`, `patch`, `post`, `delete`, `publish`, `search`). Harper's built-in static dispatch instantiates the resource and calls those instance methods, and `loadAsInstance` decides how:
+> The flag does still apply in v5 to the legacy pattern of defining REST-mirroring **instance** verbs (instance `get`, `put`, `patch`, `post`, `delete`, `publish`, `search`), where it selects the argument order those methods receive and whether the record is preloaded onto the instance. Because that behavior is live rather than inert, **`static loadAsInstance = false;` cannot simply be deleted** from an existing resource — dropping the line reverses the argument order for those instance methods and will break them. Remove it only as part of converting them to static methods.
 >
-> |                              | `loadAsInstance` unset (default)                               | `loadAsInstance = false`        |
-> | ---------------------------- | -------------------------------------------------------------- | ------------------------------- |
-> | Instance verb arguments      | `(data, target)`                                               | `(target, data)`                |
-> | Record pre-loading           | instance is pre-loaded with the record before your method runs | not pre-loaded; read explicitly |
-> | Instance `get('someString')` | treated as `getProperty('someString')`                         | treated as an id/target read    |
-> | Records passed to your code  | mutable                                                        | frozen                          |
+> The two modes are documented in full in the v4 reference — see [API Versions](../../reference_versioned_docs/version-v4/resources/resource-api.md#api-versions).
 >
-> **This is still live behavior in v5, not a no-op — so removing the line is not automatically safe.** Deleting `static loadAsInstance = false;` from a resource that still defines REST-mirroring instance methods silently flips the argument order and re-enables record pre-loading, which will break those methods. Remove it only as part of converting those instance methods to static methods.
->
-> For new code, prefer static methods and skip the flag. Reserve instance methods for record mutation via `update()` and for `validate()` — see [Resource Instance Methods](#resource-instance-methods).
+> For new code, prefer static methods and omit the flag. Reserve instance methods for record mutation via `update()` and for `validate()` — see [Resource Instance Methods](#resource-instance-methods).
 
 ---
 
@@ -874,7 +867,7 @@ The following instances are also implemented on Resource instances for [backward
 - `create`
 - `subscribe`
 
-How Harper's built-in dispatch passes arguments to these instance methods, and whether the record is pre-loaded first, depends on [`static loadAsInstance`](#static-loadasinstance-boolean). Overriding the equivalent static method avoids that dependency entirely and is preferred for new code.
+The arguments these instance methods receive depend on [`static loadAsInstance`](#static-loadasinstance-boolean). Overriding the equivalent static method avoids that dependency entirely and is preferred for new code.
 
 ## Concurrency and Safe Concurrent Writes
 

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -27,6 +27,8 @@ Static methods are defined on a Resource class and are the preferred way to inte
 
 ### `static loadAsInstance?: boolean` (deprecated)
 
+<VersionBadge type="changed" version="v5.0.0" />
+
 > **Deprecated — do not set this in v5.** In v4, `static loadAsInstance = false` opted a resource's overridden static methods (`get`, `put`, `patch`, `post`, `delete`) into the "endpoint" behavior documented throughout this section: `target` as the first argument, `data` as a promise, and `getContext()` called as a top-level function rather than `this.getContext()`. **In v5, that behavior is unconditional** — static methods always work this way regardless of whether `loadAsInstance` is set to `true`, `false`, or omitted. Adding `static loadAsInstance = false;` to a new v5 resource has no effect; it's a no-op left over from v4.
 >
 > If you find this flag in an existing resource, or an AI coding agent adds it (older example code, including some still circulating internally, uses this pattern), it's safe to delete. If the surrounding method also uses instance-style access — `this.getId()`, `this.getContext()` — inside a `static` method, convert those to the v5 equivalents: read from the `target` parameter, and call the top-level `getContext()` (imported from `harper`) instead of `this.getContext()`. Reserve actual instance methods for record mutations reached via `update()` — see [Resource Instance Methods](#resource-instance-methods) below.

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -25,6 +25,14 @@ Resource classes have static methods that directly map to RESTful methods or HTT
 
 Static methods are defined on a Resource class and are the preferred way to interact with tables and resources from application code. They handle transaction setup, access checks, and request parsing automatically. These methods also map to RESTful HTTP verbs and can be overridden to define custom behavior for requests.
 
+### `static loadAsInstance?: boolean` (deprecated)
+
+> **Deprecated — do not set this in v5.** In v4, `static loadAsInstance = false` opted a resource's overridden static methods (`get`, `put`, `patch`, `post`, `delete`) into the "endpoint" behavior documented throughout this section: `target` as the first argument, `data` as a promise, and `getContext()` called as a top-level function rather than `this.getContext()`. **In v5, that behavior is unconditional** — static methods always work this way regardless of whether `loadAsInstance` is set to `true`, `false`, or omitted. Adding `static loadAsInstance = false;` to a new v5 resource has no effect; it's a no-op left over from v4.
+>
+> If you find this flag in an existing resource, or an AI coding agent adds it (older example code, including some still circulating internally, uses this pattern), it's safe to delete. If the surrounding method also uses instance-style access — `this.getId()`, `this.getContext()` — inside a `static` method, convert those to the v5 equivalents: read from the `target` parameter, and call the top-level `getContext()` (imported from `harper`) instead of `this.getContext()`. Reserve actual instance methods for record mutations reached via `update()` — see [Resource Instance Methods](#resource-instance-methods) below.
+
+---
+
 ### `get(target: RequestTarget | Id | Query, context?: Resource | Context): Promise<object> | ExtendedIterable`
 
 Retrieves a record by primary key, or queries for records when given a `Query` object or a collection `RequestTarget`.

--- a/reference/resources/resource-api.md
+++ b/reference/resources/resource-api.md
@@ -25,13 +25,24 @@ Resource classes have static methods that directly map to RESTful methods or HTT
 
 Static methods are defined on a Resource class and are the preferred way to interact with tables and resources from application code. They handle transaction setup, access checks, and request parsing automatically. These methods also map to RESTful HTTP verbs and can be overridden to define custom behavior for requests.
 
-### `static loadAsInstance?: boolean` (deprecated)
+### `static loadAsInstance?: boolean`
 
-<VersionBadge type="changed" version="v5.0.0" />
-
-> **Deprecated — do not set this in v5.** In v4, `static loadAsInstance = false` opted a resource's overridden static methods (`get`, `put`, `patch`, `post`, `delete`) into the "endpoint" behavior documented throughout this section: `target` as the first argument, `data` as a promise, and `getContext()` called as a top-level function rather than `this.getContext()`. **In v5, that behavior is unconditional** — static methods always work this way regardless of whether `loadAsInstance` is set to `true`, `false`, or omitted. Adding `static loadAsInstance = false;` to a new v5 resource has no effect; it's a no-op left over from v4.
+> **You do not need this flag when you override static methods — which is the recommended approach.** `loadAsInstance` is a legacy compatibility flag that only affects how Harper's **built-in** dispatch calls a resource's **instance** methods. It does not change the signature or behavior of a static method you define yourself.
 >
-> If you find this flag in an existing resource, or an AI coding agent adds it (older example code, including some still circulating internally, uses this pattern), it's safe to delete. If the surrounding method also uses instance-style access — `this.getId()`, `this.getContext()` — inside a `static` method, convert those to the v5 equivalents: read from the `target` parameter, and call the top-level `getContext()` (imported from `harper`) instead of `this.getContext()`. Reserve actual instance methods for record mutations reached via `update()` — see [Resource Instance Methods](#resource-instance-methods) below.
+> When you override a static verb (`static get`, `static post`, …), your method _replaces_ the built-in dispatch — including the code that reads `loadAsInstance`. Your static method always receives `(target, data)`, so the flag is irrelevant to it. This is the main reason static methods are the recommended shape for custom endpoints: they sidestep the flag entirely.
+>
+> Where the flag still matters is the legacy pattern of defining REST-mirroring **instance** methods (instance `get`, `put`, `patch`, `post`, `delete`, `publish`, `search`). Harper's built-in static dispatch instantiates the resource and calls those instance methods, and `loadAsInstance` decides how:
+>
+> |                              | `loadAsInstance` unset (default)                               | `loadAsInstance = false`        |
+> | ---------------------------- | -------------------------------------------------------------- | ------------------------------- |
+> | Instance verb arguments      | `(data, target)`                                               | `(target, data)`                |
+> | Record pre-loading           | instance is pre-loaded with the record before your method runs | not pre-loaded; read explicitly |
+> | Instance `get('someString')` | treated as `getProperty('someString')`                         | treated as an id/target read    |
+> | Records passed to your code  | mutable                                                        | frozen                          |
+>
+> **This is still live behavior in v5, not a no-op — so removing the line is not automatically safe.** Deleting `static loadAsInstance = false;` from a resource that still defines REST-mirroring instance methods silently flips the argument order and re-enables record pre-loading, which will break those methods. Remove it only as part of converting those instance methods to static methods.
+>
+> For new code, prefer static methods and skip the flag. Reserve instance methods for record mutation via `update()` and for `validate()` — see [Resource Instance Methods](#resource-instance-methods).
 
 ---
 
@@ -862,6 +873,8 @@ The following instances are also implemented on Resource instances for [backward
 - `post`
 - `create`
 - `subscribe`
+
+How Harper's built-in dispatch passes arguments to these instance methods, and whether the record is pre-loaded first, depends on [`static loadAsInstance`](#static-loadasinstance-boolean). Overriding the equivalent static method avoids that dependency entirely and is preferred for new code.
 
 ## Concurrency and Safe Concurrent Writes
 


### PR DESCRIPTION
## Summary

`loadAsInstance` isn't mentioned anywhere in the v5 Resource API reference. With nothing in the reference to guide them, AI coding agents copying older example code (e.g. `engineering-metrics/DevLogin.ts`) reintroduce `static loadAsInstance = false;` into fresh v5 resources and then argue it's required — see the [Slack thread](https://harperdb.slack.com/archives/C3Z2T1QAZ/p1785855776089139) that prompted this.

This adds a short `static loadAsInstance?: boolean` subsection at the top of "Resource Static Methods", plus a cross-reference from the back-compat instance-method list. It deliberately does **not** restate the mode internals — the v4 reference's [API Versions](https://github.com/HarperFast/documentation/blob/main/reference_versioned_docs/version-v4/resources/resource-api.md#api-versions) section already documents both modes in full, so the v5 page links there and stays focused on what a v5 author needs to decide.

## The two things worth documenting

Verified against `resources/Resource.ts` and `resources/Table.ts` on `main`:

1. **Overridden static methods are unaffected by the flag.** It is only read inside Harper's built-in dispatch, at the point that dispatch instantiates the resource and calls the corresponding *instance* method. Defining `static get`/`static post` replaces that dispatch — including the code reading the flag — so a custom static always receives `(target, data)` regardless. This is a large part of why static methods are the recommended shape for custom endpoints, and it's the direct answer to the confusion in the thread.

2. **The flag is still live in v5, so the line is not safe to delete on its own.** It still selects the argument order for REST-mirroring instance verbs. Removing `static loadAsInstance = false;` from a resource that still defines those instance methods reverses their argument order and breaks them. It can only come out as part of converting them to statics.

## Notes for reviewers

- **Dropped the applied `VersionBadge`.** 641db8a (gemini-code-assist suggestion) added `<VersionBadge type="changed" version="v5.0.0" />`. That was premised on an earlier draft of mine which wrongly claimed v5 made the flag's behavior unconditional for static methods. The corrected text says the opposite — the instance-method behavior is unchanged and still live — so a "changed in v5.0.0" badge would be inaccurate. Happy to add a plain (non-`changed`) badge instead if we want one here.
- **Dropped a behavior-comparison table** that an earlier revision included. One row claimed records are mutable in default mode and frozen with the flag; that conflated the record (frozen either way) with the Resource instance the instance verbs are called on (mutable). Deferring to the v4 doc avoids re-deriving these details in two places.

## Test plan

- [x] Mechanism verified against `resources/Resource.ts` (the `loadAsInstance` branches inside each verb's `transactional` dispatch) and `resources/Table.ts` (`getResource` preload, `get(string)` semantics, permission placement)
- [x] `npx prettier --write reference/resources/resource-api.md` — clean
- [x] Anchors confirmed against github-slugger output (`#api-versions`, `#resource-instance-methods`, `#static-loadasinstance-boolean`); repo uses generated slugs, not explicit heading ids
- [x] Relative path to `reference_versioned_docs/version-v4/...` matches the existing cross-version link already in this file
- [ ] Docs site preview / review

🤖 Generated with [Claude Code](https://claude.com/claude-code)