### PR TITLE
Document copy-db's blob companion directory and restore steps

### DIFF
--- a/reference/cli/commands.md
+++ b/reference/cli/commands.md
@@ -250,8 +250,8 @@ harper copy-db <source-database> <target-database-path>
 
 **Parameters**:
 
-- `<source-database>` - Name of the source database
-- `<target-database-path>` - Full path to the target database file
+- `<source-database>` - Name of the source database (a name, not a file path)
+- `<target-database-path>` - Full path to the target database file, which must not already exist
 
 **Example**:
 
@@ -260,6 +260,8 @@ harper copy-db data /home/user/hdb/database/copy.mdb
 ```
 
 This copies the default `data` database to a new location with compaction applied.
+
+The database's file-backed blobs are copied to `<target-database-path>-blobs/<rootIndex>/`, since blob files live outside the database file and are addressed by database name. The copy cannot be restored without that directory — see [Database Compaction](../database/compaction.md#file-backed-blobs-travel-separately) for the restore steps. LMDB databases only; RocksDB databases compact themselves.
 
 **Use Cases**:
 

--- a/reference/database/compaction.md
+++ b/reference/database/compaction.md
@@ -27,7 +27,7 @@ Run using the [CLI](../cli/commands.md):
 harper copy-db <source-database> <target-database-path>
 ```
 
-The `source-database` is the database name (not a file path). The target is the full file path where the compacted copy will be written.
+The `source-database` is the database name (not a file path). The target is the full file path where the compacted copy will be written, and it must not already exist — `copy-db` refuses to write into an existing file rather than merging the copy into whatever it holds.
 
 To replace the original database with the compacted copy, move or rename the output file to the original database path after Harper is stopped.
 
@@ -36,6 +36,29 @@ To replace the original database with the compacted copy, move or rename the out
 ```bash
 harper copy-db data /home/user/hdb/database/copy.mdb
 ```
+
+Copy compaction applies to LMDB databases. RocksDB databases compact themselves and are skipped.
+
+### File-backed blobs travel separately
+
+A database's file-backed blob values (`Blob` and large `Bytes` attributes) are not stored inside the database file. They live in the configured blob roots — `storage.blobPaths[n]`, or `<rootPath>/blobs/<database>` when `blobPaths` is not configured — and are addressed by **database name**, not by the path of the database file.
+
+`copy-db` therefore writes them alongside the copy:
+
+```
+<target-database-path>-blobs/<rootIndex>/…
+```
+
+`<rootIndex>` is the position of the source root in the database's blob-root list, preserved so a multi-root database restores each root to its original slot. A `README.md` in that directory records the mapping.
+
+**The copy is not restorable without this directory.** To restore the copy under a database name, put each `<rootIndex>` tree into that name's matching blob root — for example, restoring the copy above as a database named `archive` with no `storage.blobPaths` configured:
+
+```bash
+cp -r /home/user/hdb/database/copy.mdb /home/user/hdb/database/archive.mdb
+cp -r /home/user/hdb/database/copy.mdb-blobs/0/. /home/user/hdb/blobs/archive/
+```
+
+Restoring the copy under its original database name in the same installation needs only the database file, since the blob roots it already references are untouched.
 
 ## Compact on Start
 


### PR DESCRIPTION
Companion to HarperFast/harper#2098 (fixes HarperFast/harper#2048).

`copy-db` previously left the database's file-backed blobs behind, so a copy moved to another host, or restored under a different database name, silently lost every blob. It now copies each blob root to `<target>-blobs/<rootIndex>/` alongside the database file, and refuses a target that already exists rather than merging the copy into it.

Documents:

- the blob companion directory, its `<rootIndex>` layout, and the restore steps (including restoring under a different database name, which is where the blob roots have to be placed by hand)
- that the target path must not already exist
- that copy compaction is LMDB-only — RocksDB databases compact themselves

Generated by Claude Opus 5.
