### PR TITLE
Document storage.blobRetention

### DIFF
--- a/reference/database/storage-tuning.md
+++ b/reference/database/storage-tuning.md
@@ -102,6 +102,27 @@ storage:
 
 Blobs are not relocated when `blobPaths` changes — only new blobs honor the updated configuration. Existing blob references continue to resolve at their original path.
 
+### `storage.blobRetention`
+
+Type: `number` (milliseconds)
+
+Default: `2000`
+
+How long a superseded blob file is kept on disk after the record that referenced it is overwritten or removed.
+
+A blob's bytes are read lazily: a request resolves the record first, then opens the backing file when it starts streaming the response. If the record is overwritten in between, the file it pointed at is on its way out — and because the failure surfaces after the response headers are already committed, the client sees a truncated body rather than an error status. `blobRetention` is the window that lets those in-flight reads finish.
+
+Raise it when reads are slow enough to outlive the default window — large blobs, slow or heavily backpressured clients, or a busy cache table whose entries are rewritten while being served. Replication peers that have not yet fetched a superseded blob are also covered by this window, so a cluster with significant replication lag wants a value comfortably above that lag.
+
+The cost is disk: superseded blobs written during the window stay on disk for its duration, so the overhang is roughly your blob write rate multiplied by the retention window. Set it to `0` to reclaim as soon as the queue drains.
+
+```yaml
+storage:
+  blobRetention: 30000
+```
+
+If the process exits before a deferred reclamation runs, the file is left behind until the `cleanup_orphan_blobs` operation reclaims it — a longer window widens that gap.
+
 ## Read & Write Behavior
 
 ### `storage.prefetchWrites`


### PR DESCRIPTION
Documents `storage.blobRetention`, the new config option added in HarperFast/harper#2145.

The option controls how long a superseded blob file stays on disk. The section explains why the window exists (blob bytes are read lazily, so a request that resolved a record just before it was overwritten opens the file afterwards — and the resulting failure lands after the response headers are committed, so the client sees a truncated body rather than an error), when to raise it (large blobs, slow clients, a cache table rewritten while being served, replication lag), and what it costs (write rate × window of superseded bytes on disk, plus a wider window for files orphaned by an abrupt exit).

Placed in `reference/database/storage-tuning.md` next to `storage.blobPaths`, matching the surrounding option format.

## Verification

Prose-only change to an existing reference page; no build run — `npx prettier` cannot run in this worktree (`@harperfast/code-guidelines` is not installed), so formatting was matched to the surrounding sections by hand. Worth a docs-site preview check before merge.

## For the human reviewer

One judgment call: I documented the replication-lag guidance ("a cluster with significant replication lag wants a value comfortably above that lag") as a real tuning lever. That is accurate for the current design but is exactly the workaround that lag-aware retention would remove — if harper#2145's judgment call 1 goes the other way, this paragraph should be revisited rather than kept.

🤖 Generated by Claude (claude-opus-5)
