### PR TITLE
Document replication.blobGapReconnectMs and bulk-copy cursor flush options

### DIFF
--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -226,6 +226,9 @@ replication:
 - `securePort` — Secure replication port; _Default_: `9933` (changed from `9925` in v4.5.0)
 - `enableRootCAs` — Verify against Node.js Mozilla CA store; _Default_: `true`
 - `blobTimeout` — Blob transfer timeout (ms); _Default_: `120000`
+- `blobGapReconnectMs` — Interval (ms) for the blob-gap watchdog: when a transient blob save failure pins a replication resume cursor, the connection is forced to reconnect on this cadence so the gapped blob is re-streamed and, during a bulk copy, the copy resumes from the last banked cursor. Lower values heal gaps faster at the cost of more reconnects on a link whose faults never heal; _Default_: the `blobTimeout` value
+- `copyCursorFlushBytes` — Bytes of applied bulk-copy data between durable flushes of the copy resume cursor (RocksDB); _Default_: `67108864`
+- `copyCursorFlushIntervalMs` — Maximum time (ms) between durable flushes of the bulk-copy resume cursor (RocksDB); _Default_: `5000`
 - `blobSendDrainTimeout` — Maximum time (ms) a worker waits for in-flight replication blob **sends** to finish before shutting down during a restart, so a rolling restart (e.g., a component deploy reload) doesn't interrupt a transfer in progress. Only sends that are still making progress are waited on; `0` disables draining; _Default_: `600000`
 - `failOver` — Failover to alternate node if peer unreachable; _Default_: `true`
 - `shard` — Shard ID for traffic routing; see [Sharding](../replication/sharding.md)


### PR DESCRIPTION
Documents the blob-gap watchdog interval added in [harper#2177](https://github.com/HarperFast/harper/pull/2177) (consumed by [harper-pro#701](https://github.com/HarperFast/harper-pro/pull/701)) and the existing bulk-copy cursor flush cadence knobs (`copyCursorFlushBytes`/`copyCursorFlushIntervalMs`, harper-pro#480) that became configurable with the same change. Merge together with those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)