### PR TITLE
Add companion-check workflow: docs PRs auto-merge once their companion code PR lands

### DIFF
--- a/.github/workflows/companion-check.yaml
+++ b/.github/workflows/companion-check.yaml
@@ -1,0 +1,157 @@
+# Gates PR merges on companion PRs in other repos.
+#
+# Add one or more markers to a PR body:
+#   Depends-on: HarperFast/harper#2147
+#   Depends-on: https://github.com/HarperFast/harper-pro/pull/512
+#
+# The `companion-check` commit status stays pending until every referenced PR
+# is merged, and fails if one closes without merging. With `companion-check`
+# configured as a required status check, approving a PR and arming auto-merge
+# queues it to merge automatically once its companions land.
+#
+# PRs without a marker get an immediate `success` status, so the required
+# check never blocks ordinary PRs.
+#
+# Referencing a private repo requires a `COMPANION_CHECK_TOKEN` secret with
+# pull-request read access to that repo; public repos work with GITHUB_TOKEN.
+#
+# `pull_request_target` is safe here: the workflow never checks out or
+# executes PR code, and the PR body is only ever handled as data inside
+# github-script.
+
+name: Companion Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  statuses: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: companion-check-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate companion dependencies
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          COMPANION_CHECK_TOKEN: ${{ secrets.COMPANION_CHECK_TOKEN }}
+        with:
+          script: |
+            const STATUS_CONTEXT = 'companion-check';
+            const { owner, repo } = context.repo;
+            const crossToken = process.env.COMPANION_CHECK_TOKEN || '';
+
+            function parseDeps(body) {
+              const deps = [];
+              const lineRe = /^\s*depends-on:\s*(.+)$/gim;
+              const refRe =
+                /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)|([\w.-]+)\/([\w.-]+)#(\d+)|(?:^|[\s,])#(\d+)/g;
+              for (const [, refs] of (body || '').matchAll(lineRe)) {
+                for (const m of refs.matchAll(refRe)) {
+                  if (m[3]) deps.push({ owner: m[1], repo: m[2], number: +m[3] });
+                  else if (m[6]) deps.push({ owner: m[4], repo: m[5], number: +m[6] });
+                  else deps.push({ owner, repo, number: +m[7] });
+                }
+              }
+              return deps;
+            }
+
+            const refOf = (dep) => `${dep.owner}/${dep.repo}#${dep.number}`;
+
+            async function depState(dep) {
+              try {
+                const { data } = await github.rest.pulls.get({
+                  owner: dep.owner,
+                  repo: dep.repo,
+                  pull_number: dep.number,
+                });
+                return data.merged ? 'merged' : data.state === 'open' ? 'open' : 'closed';
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+              if (crossToken) {
+                const res = await fetch(
+                  `https://api.github.com/repos/${dep.owner}/${dep.repo}/pulls/${dep.number}`,
+                  {
+                    headers: {
+                      authorization: `Bearer ${crossToken}`,
+                      accept: 'application/vnd.github+json',
+                    },
+                  }
+                );
+                if (res.ok) {
+                  const data = await res.json();
+                  return data.merged ? 'merged' : data.state === 'open' ? 'open' : 'closed';
+                }
+              }
+              return 'unreadable';
+            }
+
+            async function evaluate(deps) {
+              if (!deps.length) return { state: 'success', description: 'No companion dependencies' };
+              const states = [];
+              for (const dep of deps) states.push({ ref: refOf(dep), state: await depState(dep) });
+              const closed = states.find((s) => s.state === 'closed');
+              if (closed)
+                return { state: 'failure', description: `${closed.ref} closed without merging` };
+              const unreadable = states.find((s) => s.state === 'unreadable');
+              if (unreadable)
+                return {
+                  state: 'pending',
+                  description: `Cannot read ${unreadable.ref} - COMPANION_CHECK_TOKEN needed?`,
+                };
+              const open = states.filter((s) => s.state === 'open');
+              if (open.length)
+                return {
+                  state: 'pending',
+                  description: `Waiting on ${open.map((s) => s.ref).join(', ')}`,
+                };
+              return {
+                state: 'success',
+                description: `All companion PRs merged (${states.map((s) => s.ref).join(', ')})`,
+              };
+            }
+
+            async function postIfChanged(pr, desired) {
+              const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+                owner,
+                repo,
+                ref: pr.head.sha,
+                per_page: 100,
+              });
+              const description = desired.description.slice(0, 140);
+              const current = statuses.find((s) => s.context === STATUS_CONTEXT);
+              if (current && current.state === desired.state && current.description === description)
+                return;
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha: pr.head.sha,
+                context: STATUS_CONTEXT,
+                state: desired.state,
+                description,
+                target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              });
+              core.info(`${pr.number} -> ${desired.state}: ${description}`);
+            }
+
+            const prs =
+              context.eventName === 'pull_request_target'
+                ? [context.payload.pull_request]
+                : await github.paginate(github.rest.pulls.list, {
+                    owner,
+                    repo,
+                    state: 'open',
+                    per_page: 100,
+                  });
+            for (const pr of prs) await postIfChanged(pr, await evaluate(parseDeps(pr.body)));

--- a/.github/workflows/companion-check.yaml
+++ b/.github/workflows/companion-check.yaml
@@ -5,19 +5,23 @@
 #   Depends-on: https://github.com/HarperFast/harper-pro/pull/512
 #
 # The `companion-check` commit status stays pending until every referenced PR
-# is merged, and fails if one closes without merging. With `companion-check`
+# is merged, and fails if one closes without merging (or if a marker is
+# present but unparseable — the gate fails closed). With `companion-check`
 # configured as a required status check, approving a PR and arming auto-merge
 # queues it to merge automatically once its companions land.
 #
 # PRs without a marker get an immediate `success` status, so the required
-# check never blocks ordinary PRs.
+# check never blocks ordinary PRs. The cron sweep only re-evaluates PRs that
+# carry a marker; a full pass over every open PR (e.g. to backfill statuses
+# right after this workflow first lands) is a manual workflow_dispatch run.
 #
 # Referencing a private repo requires a `COMPANION_CHECK_TOKEN` secret with
 # pull-request read access to that repo; public repos work with GITHUB_TOKEN.
+# The secret is only ever used for repos in this repo's own org.
 #
-# `pull_request_target` is safe here: the workflow never checks out or
-# executes PR code, and the PR body is only ever handled as data inside
-# github-script.
+# Maintenance rule for `pull_request_target`: never add a checkout step and
+# never interpolate PR-controlled text into `run:` or expressions — the PR
+# body must only be handled as data inside github-script.
 
 name: Companion Check
 
@@ -35,7 +39,7 @@ permissions:
 
 concurrency:
   group: companion-check-${{ github.event.pull_request.number || 'sweep' }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
   evaluate:
@@ -48,25 +52,41 @@ jobs:
         with:
           script: |
             const STATUS_CONTEXT = 'companion-check';
+            const MAX_DEPS = 10;
             const { owner, repo } = context.repo;
             const crossToken = process.env.COMPANION_CHECK_TOKEN || '';
+            const isSweep = context.eventName !== 'pull_request_target';
 
             function parseDeps(body) {
               const deps = [];
-              const lineRe = /^\s*depends-on:\s*(.+)$/gim;
+              let unparseable = false;
+              const lineRe = /^[^\S\r\n]*depends[- ]on:[ \t]*(.+)$/gim;
               const refRe =
-                /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)|([\w.-]+)\/([\w.-]+)#(\d+)|(?:^|[\s,])#(\d+)/g;
+                /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)|([\w.-]+)\/([\w.-]+)#(\d+)|([\w.-]+)#(\d+)|(?:^|[\s,])#(\d+)/g;
               for (const [, refs] of (body || '').matchAll(lineRe)) {
+                let matched = 0;
                 for (const m of refs.matchAll(refRe)) {
+                  matched++;
                   if (m[3]) deps.push({ owner: m[1], repo: m[2], number: +m[3] });
                   else if (m[6]) deps.push({ owner: m[4], repo: m[5], number: +m[6] });
-                  else deps.push({ owner, repo, number: +m[7] });
+                  else if (m[8]) deps.push({ owner, repo: m[7], number: +m[8] });
+                  else deps.push({ owner, repo, number: +m[9] });
                 }
+                if (!matched) unparseable = true;
               }
-              return deps;
+              const seen = new Set();
+              const unique = deps.filter((dep) => {
+                const key = `${dep.owner}/${dep.repo}#${dep.number}`.toLowerCase();
+                if (seen.has(key)) return false;
+                seen.add(key);
+                return true;
+              });
+              return { deps: unique, unparseable };
             }
 
             const refOf = (dep) => `${dep.owner}/${dep.repo}#${dep.number}`;
+            const stateOf = (data) =>
+              data.merged ? 'merged' : data.state === 'open' ? 'open' : 'closed';
 
             async function depState(dep) {
               try {
@@ -75,40 +95,57 @@ jobs:
                   repo: dep.repo,
                   pull_number: dep.number,
                 });
-                return data.merged ? 'merged' : data.state === 'open' ? 'open' : 'closed';
+                return stateOf(data);
               } catch (e) {
-                if (e.status !== 404) throw e;
+                if (e.status !== 404) return `unreadable (${e.status || e.message})`;
               }
-              if (crossToken) {
-                const res = await fetch(
-                  `https://api.github.com/repos/${dep.owner}/${dep.repo}/pulls/${dep.number}`,
-                  {
-                    headers: {
-                      authorization: `Bearer ${crossToken}`,
-                      accept: 'application/vnd.github+json',
-                    },
-                  }
-                );
-                if (res.ok) {
-                  const data = await res.json();
-                  return data.merged ? 'merged' : data.state === 'open' ? 'open' : 'closed';
+              // The secret only accompanies requests for repos in our own org.
+              if (crossToken && dep.owner.toLowerCase() === owner.toLowerCase()) {
+                try {
+                  const res = await fetch(
+                    `https://api.github.com/repos/${dep.owner}/${dep.repo}/pulls/${dep.number}`,
+                    {
+                      headers: {
+                        authorization: `Bearer ${crossToken}`,
+                        accept: 'application/vnd.github+json',
+                        'user-agent': 'companion-check',
+                      },
+                    }
+                  );
+                  if (res.ok) return stateOf(await res.json());
+                  return `unreadable (${res.status})`;
+                } catch (e) {
+                  return `unreadable (${e.message})`;
                 }
               }
-              return 'unreadable';
+              return 'unreadable (404)';
             }
 
-            async function evaluate(deps) {
-              if (!deps.length) return { state: 'success', description: 'No companion dependencies' };
+            async function evaluate({ deps, unparseable }) {
+              if (unparseable)
+                return {
+                  state: 'failure',
+                  description: 'Unparseable Depends-on marker (use owner/repo#N or a PR URL)',
+                };
+              if (!deps.length)
+                return { state: 'success', description: 'No companion dependencies' };
+              if (deps.length > MAX_DEPS)
+                return {
+                  state: 'failure',
+                  description: `More than ${MAX_DEPS} companion PRs referenced`,
+                };
               const states = [];
               for (const dep of deps) states.push({ ref: refOf(dep), state: await depState(dep) });
               const closed = states.find((s) => s.state === 'closed');
               if (closed)
                 return { state: 'failure', description: `${closed.ref} closed without merging` };
-              const unreadable = states.find((s) => s.state === 'unreadable');
+              const unreadable = states.find((s) => s.state.startsWith('unreadable'));
               if (unreadable)
                 return {
                   state: 'pending',
-                  description: `Cannot read ${unreadable.ref} - COMPANION_CHECK_TOKEN needed?`,
+                  description:
+                    `Cannot read ${unreadable.ref} ${unreadable.state.slice(11)}` +
+                    (crossToken ? '' : ' - COMPANION_CHECK_TOKEN needed?'),
                 };
               const open = states.filter((s) => s.state === 'open');
               if (open.length)
@@ -133,6 +170,16 @@ jobs:
               const current = statuses.find((s) => s.context === STATUS_CONTEXT);
               if (current && current.state === desired.state && current.description === description)
                 return;
+              if (isSweep) {
+                // A sweep races PR events: re-read the PR and let the fresher
+                // event (or the next sweep) handle anything that moved.
+                const { data: fresh } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                });
+                if (fresh.head.sha !== pr.head.sha || fresh.body !== pr.body) return;
+              }
               await github.rest.repos.createCommitStatus({
                 owner,
                 repo,
@@ -154,4 +201,16 @@ jobs:
                     state: 'open',
                     per_page: 100,
                   });
-            for (const pr of prs) await postIfChanged(pr, await evaluate(parseDeps(pr.body)));
+            let failures = 0;
+            for (const pr of prs) {
+              try {
+                const parsed = parseDeps(pr.body);
+                if (context.eventName === 'schedule' && !parsed.deps.length && !parsed.unparseable)
+                  continue;
+                await postIfChanged(pr, await evaluate(parsed));
+              } catch (e) {
+                failures++;
+                core.warning(`PR #${pr.number}: ${e.message}`);
+              }
+            }
+            if (failures) core.setFailed(`${failures} PR(s) could not be updated`);

--- a/.github/workflows/companion-check.yaml
+++ b/.github/workflows/companion-check.yaml
@@ -163,7 +163,7 @@ jobs:
                 return { state: 'failure', description: `${closed.ref} closed without merging` };
               const missing = states.find((s) => s.state === 'missing');
               if (missing)
-                return { state: 'failure', description: `${missing.ref} not found (typo?)` };
+                return { state: 'failure', description: `${missing.ref} not found (typo, or token lacks access?)` };
               const unreadable = states.find((s) => s.state.startsWith('unreadable'));
               if (unreadable)
                 return {

--- a/.github/workflows/companion-check.yaml
+++ b/.github/workflows/companion-check.yaml
@@ -119,6 +119,7 @@ jobs:
                 return stateOf(data);
               } catch (e) {
                 if (e.status !== 404) return `unreadable (${e.status || e.message})`;
+                // 404 falls through: definitive miss unless the secret can see more.
               }
               // Oracle guard: the secret never serves foreign-org refs or fork PRs.
               if (crossToken && allowSecret && dep.owner.toLowerCase() === owner.toLowerCase()) {
@@ -139,7 +140,7 @@ jobs:
                   return `unreadable (${e.message})`;
                 }
               }
-              return 'unreadable (404)';
+              return 'missing';
             }
 
             async function evaluate({ deps, unparseable }, allowSecret) {
@@ -163,14 +164,15 @@ jobs:
                 return { state: 'failure', description: `${closed.ref} closed without merging` };
               const missing = states.find((s) => s.state === 'missing');
               if (missing)
-                return { state: 'failure', description: `${missing.ref} not found (typo, or token lacks access?)` };
+                return {
+                  state: 'failure',
+                  description: `${missing.ref} not found or inaccessible (typo? private repo needs COMPANION_CHECK_TOKEN?)`,
+                };
               const unreadable = states.find((s) => s.state.startsWith('unreadable'));
               if (unreadable)
                 return {
                   state: 'pending',
-                  description:
-                    `Cannot read ${unreadable.ref} ${unreadable.state.slice(11)}` +
-                    (crossToken ? '' : ' - COMPANION_CHECK_TOKEN needed?'),
+                  description: `Cannot read ${unreadable.ref} ${unreadable.state.slice(11)}`,
                 };
               const open = states.filter((s) => s.state === 'open');
               if (open.length)

--- a/.github/workflows/companion-check.yaml
+++ b/.github/workflows/companion-check.yaml
@@ -2,26 +2,32 @@
 #
 # Add one or more markers to a PR body:
 #   Depends-on: HarperFast/harper#2147
+#   Depends-on: harper#2147            (same-org shorthand)
 #   Depends-on: https://github.com/HarperFast/harper-pro/pull/512
+#
+# A marker line may only contain refs in those forms (comma/space separated);
+# anything else on the line fails the check rather than being ignored.
 #
 # The `companion-check` commit status stays pending until every referenced PR
 # is merged, and fails if one closes without merging (or if a marker is
-# present but unparseable — the gate fails closed). With `companion-check`
-# configured as a required status check, approving a PR and arming auto-merge
-# queues it to merge automatically once its companions land.
+# present but empty/unparseable — the gate fails closed). With
+# `companion-check` configured as a required status check, approving a PR and
+# arming auto-merge queues it to merge automatically once its companions land.
 #
 # PRs without a marker get an immediate `success` status, so the required
-# check never blocks ordinary PRs. The cron sweep only re-evaluates PRs that
-# carry a marker; a full pass over every open PR (e.g. to backfill statuses
-# right after this workflow first lands) is a manual workflow_dispatch run.
+# check never blocks ordinary PRs. The cron sweep reconciles every open PR,
+# so it also backfills statuses after this workflow first lands and heals
+# any status a dropped webhook left behind.
 #
 # Referencing a private repo requires a `COMPANION_CHECK_TOKEN` secret with
 # pull-request read access to that repo; public repos work with GITHUB_TOKEN.
-# The secret is only ever used for repos in this repo's own org.
+# The secret is only used for same-org refs on non-fork PRs.
 #
 # Maintenance rule for `pull_request_target`: never add a checkout step and
 # never interpolate PR-controlled text into `run:` or expressions — the PR
 # body must only be handled as data inside github-script.
+#
+# Logic is covered by scripts/companion-check.test.mjs (plain node, no deps).
 
 name: Companion Check
 
@@ -56,23 +62,30 @@ jobs:
             const { owner, repo } = context.repo;
             const crossToken = process.env.COMPANION_CHECK_TOKEN || '';
             const isSweep = context.eventName !== 'pull_request_target';
+            const apiUrl = context.apiUrl || 'https://api.github.com';
+            const depCache = new Map();
 
             function parseDeps(body) {
               const deps = [];
               let unparseable = false;
-              const lineRe = /^[^\S\r\n]*depends[- ]on:[ \t]*(.+)$/gim;
+              const lineRe = /^[^\S\r\n]*depends[- ]on:[ \t]*(.*)$/gim;
               const refRe =
-                /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)|([\w.-]+)\/([\w.-]+)#(\d+)|([\w.-]+)#(\d+)|(?:^|[\s,])#(\d+)/g;
+                /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)|([\w.-]+)\/([\w.-]+)#(\d+)|([\w.-]+)#(\d+)/g;
+              const badSegment = (s) => s.includes('..') || s.startsWith('.');
               for (const [, refs] of (body || '').matchAll(lineRe)) {
                 let matched = 0;
                 for (const m of refs.matchAll(refRe)) {
                   matched++;
-                  if (m[3]) deps.push({ owner: m[1], repo: m[2], number: +m[3] });
-                  else if (m[6]) deps.push({ owner: m[4], repo: m[5], number: +m[6] });
-                  else if (m[8]) deps.push({ owner, repo: m[7], number: +m[8] });
-                  else deps.push({ owner, repo, number: +m[9] });
+                  const dep = m[3]
+                    ? { owner: m[1], repo: m[2], number: +m[3] }
+                    : m[6]
+                      ? { owner: m[4], repo: m[5], number: +m[6] }
+                      : { owner, repo: m[7], number: +m[8] };
+                  if (badSegment(dep.owner) || badSegment(dep.repo)) unparseable = true;
+                  else deps.push(dep);
                 }
-                if (!matched) unparseable = true;
+                // Anything on the line that is not a recognized ref fails closed.
+                if (!matched || refs.replace(refRe, '').replace(/[\s,;]+/g, '')) unparseable = true;
               }
               const seen = new Set();
               const unique = deps.filter((dep) => {
@@ -88,7 +101,15 @@ jobs:
             const stateOf = (data) =>
               data.merged ? 'merged' : data.state === 'open' ? 'open' : 'closed';
 
-            async function depState(dep) {
+            async function depState(dep, allowSecret) {
+              const cacheKey = `${allowSecret}:${refOf(dep).toLowerCase()}`;
+              if (depCache.has(cacheKey)) return depCache.get(cacheKey);
+              const state = await depStateUncached(dep, allowSecret);
+              depCache.set(cacheKey, state);
+              return state;
+            }
+
+            async function depStateUncached(dep, allowSecret) {
               try {
                 const { data } = await github.rest.pulls.get({
                   owner: dep.owner,
@@ -99,11 +120,11 @@ jobs:
               } catch (e) {
                 if (e.status !== 404) return `unreadable (${e.status || e.message})`;
               }
-              // The secret only accompanies requests for repos in our own org.
-              if (crossToken && dep.owner.toLowerCase() === owner.toLowerCase()) {
+              // Oracle guard: the secret never serves foreign-org refs or fork PRs.
+              if (crossToken && allowSecret && dep.owner.toLowerCase() === owner.toLowerCase()) {
                 try {
                   const res = await fetch(
-                    `https://api.github.com/repos/${dep.owner}/${dep.repo}/pulls/${dep.number}`,
+                    `${apiUrl}/repos/${encodeURIComponent(dep.owner)}/${encodeURIComponent(dep.repo)}/pulls/${dep.number}`,
                     {
                       headers: {
                         authorization: `Bearer ${crossToken}`,
@@ -113,7 +134,7 @@ jobs:
                     }
                   );
                   if (res.ok) return stateOf(await res.json());
-                  return `unreadable (${res.status})`;
+                  return res.status === 404 ? 'missing' : `unreadable (${res.status})`;
                 } catch (e) {
                   return `unreadable (${e.message})`;
                 }
@@ -121,11 +142,11 @@ jobs:
               return 'unreadable (404)';
             }
 
-            async function evaluate({ deps, unparseable }) {
+            async function evaluate({ deps, unparseable }, allowSecret) {
               if (unparseable)
                 return {
                   state: 'failure',
-                  description: 'Unparseable Depends-on marker (use owner/repo#N or a PR URL)',
+                  description: 'Empty or unparseable Depends-on marker (use owner/repo#N or a PR URL)',
                 };
               if (!deps.length)
                 return { state: 'success', description: 'No companion dependencies' };
@@ -135,10 +156,14 @@ jobs:
                   description: `More than ${MAX_DEPS} companion PRs referenced`,
                 };
               const states = [];
-              for (const dep of deps) states.push({ ref: refOf(dep), state: await depState(dep) });
+              for (const dep of deps)
+                states.push({ ref: refOf(dep), state: await depState(dep, allowSecret) });
               const closed = states.find((s) => s.state === 'closed');
               if (closed)
                 return { state: 'failure', description: `${closed.ref} closed without merging` };
+              const missing = states.find((s) => s.state === 'missing');
+              if (missing)
+                return { state: 'failure', description: `${missing.ref} not found (typo?)` };
               const unreadable = states.find((s) => s.state.startsWith('unreadable'));
               if (unreadable)
                 return {
@@ -159,6 +184,20 @@ jobs:
               };
             }
 
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            async function postStatus(sha, state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha,
+                context: STATUS_CONTEXT,
+                state,
+                description: description.slice(0, 140),
+                target_url: runUrl,
+              });
+            }
+
             async function postIfChanged(pr, desired) {
               const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
                 owner,
@@ -171,8 +210,7 @@ jobs:
               if (current && current.state === desired.state && current.description === description)
                 return;
               if (isSweep) {
-                // A sweep races PR events: re-read the PR and let the fresher
-                // event (or the next sweep) handle anything that moved.
+                // Sweep data may predate a racing PR event; the fresher run wins.
                 const { data: fresh } = await github.rest.pulls.get({
                   owner,
                   repo,
@@ -180,15 +218,7 @@ jobs:
                 });
                 if (fresh.head.sha !== pr.head.sha || fresh.body !== pr.body) return;
               }
-              await github.rest.repos.createCommitStatus({
-                owner,
-                repo,
-                sha: pr.head.sha,
-                context: STATUS_CONTEXT,
-                state: desired.state,
-                description,
-                target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
-              });
+              await postStatus(pr.head.sha, desired.state, description);
               core.info(`${pr.number} -> ${desired.state}: ${description}`);
             }
 
@@ -203,14 +233,21 @@ jobs:
                   });
             let failures = 0;
             for (const pr of prs) {
+              let parsed;
               try {
-                const parsed = parseDeps(pr.body);
-                if (context.eventName === 'schedule' && !parsed.deps.length && !parsed.unparseable)
-                  continue;
-                await postIfChanged(pr, await evaluate(parsed));
+                parsed = parseDeps(pr.body);
+                const allowSecret =
+                  !!pr.head.repo && pr.head.repo.full_name === `${owner}/${repo}`;
+                await postIfChanged(pr, await evaluate(parsed, allowSecret));
               } catch (e) {
                 failures++;
                 core.warning(`PR #${pr.number}: ${e.message}`);
+                // A failed refresh must not leave a stale success behind.
+                if (parsed && (parsed.deps.length || parsed.unparseable)) {
+                  try {
+                    await postStatus(pr.head.sha, 'pending', 'companion-check errored; next run will retry');
+                  } catch {}
+                }
               }
             }
             if (failures) core.setFailed(`${failures} PR(s) could not be updated`);

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,6 +19,7 @@ jobs:
           - TypeScript Check
           - Lint Check
           - Format Check
+          - Workflow Tests
         include:
           - check: TypeScript Check
             command: typecheck
@@ -26,6 +27,8 @@ jobs:
             command: lint
           - check: Format Check
             command: format:check
+          - check: Workflow Tests
+            command: test:workflows
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"format:check": "npm run format -- --check",
 		"format:write": "npm run format -- --write",
 		"lint": "echo 0;",
-		"preview:pr": "node scripts/preview-pr.mjs"
+		"preview:pr": "node scripts/preview-pr.mjs",
+		"test:workflows": "node scripts/companion-check.test.mjs"
 	},
 	"devDependencies": {
 		"@docusaurus/core": "3.9.2",

--- a/scripts/companion-check.test.mjs
+++ b/scripts/companion-check.test.mjs
@@ -1,0 +1,200 @@
+// Test harness for the companion-check workflow's embedded github-script.
+// Usage: node scripts/companion-check.test.mjs [path-to-companion-check.yaml]
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert';
+
+const yaml = readFileSync(
+	process.argv[2] || new URL('../.github/workflows/companion-check.yaml', import.meta.url),
+	'utf8'
+);
+const script = yaml
+	.split('\n')
+	.filter((l) => /^ {12}/.test(l) || l.trim() === '')
+	.map((l) => l.slice(12))
+	.join('\n');
+assert(script.includes('parseDeps'), 'script extraction failed');
+
+const OWN = 'HarperFast/documentation';
+
+// Dep PR database: "owner/repo#n" -> PR data | 'private' | 'flaky500'
+const prDb = {
+	'HarperFast/harper#2147': { merged: false, state: 'open' },
+	'HarperFast/harper#2000': { merged: true, state: 'closed' },
+	'HarperFast/harper#1999': { merged: false, state: 'closed' },
+	'HarperFast/harper#1500': { merged: true, state: 'closed' },
+	'HarperFast/harper-pro#512': 'private',
+	'HarperFast/harper#666': 'flaky500',
+	'HarperFast/documentation#600': { merged: true, state: 'closed' },
+};
+
+function makeEnv(eventName, openPrs, payloadPr) {
+	const posted = [];
+	const getCalls = [];
+	const github = {
+		rest: {
+			pulls: {
+				get: async ({ owner, repo, pull_number }) => {
+					const key = `${owner}/${repo}#${pull_number}`;
+					getCalls.push(key);
+					const fresh = openPrs.find((p) => key === `${OWN}#${p.number}`);
+					if (fresh) return { data: fresh }; // sweep re-read of our own PR
+					const rec = prDb[key];
+					if (rec === 'flaky500') throw Object.assign(new Error('boom'), { status: 500 });
+					if (!rec || rec === 'private') throw Object.assign(new Error('nf'), { status: 404 });
+					return { data: rec };
+				},
+				list: 'LIST',
+			},
+			repos: {
+				listCommitStatusesForRef: async ({ ref }) => ({
+					data:
+						ref === 'ddd'
+							? [
+									{
+										context: 'companion-check',
+										state: 'failure',
+										description: 'HarperFast/harper#1999 closed without merging',
+									},
+								]
+							: ref === 'heal'
+								? [{ context: 'companion-check', state: 'pending', description: 'Waiting on HarperFast/harper#2147' }]
+								: [],
+				}),
+				createCommitStatus: async (s) => posted.push(s),
+			},
+		},
+		paginate: async (fn) => (assert.equal(fn, 'LIST'), openPrs),
+	};
+	const core = { info: () => {}, warning: () => {}, setFailed: (m) => (core.failed = m) };
+	const context = {
+		repo: { owner: 'HarperFast', repo: 'documentation' },
+		eventName,
+		payload: { pull_request: payloadPr },
+		serverUrl: 'https://github.com',
+		runId: 1,
+	};
+	return { github, core, context, posted, getCalls };
+}
+
+async function run(env) {
+	await new Function('github', 'context', 'core', `return (async()=>{${script}})()`)(env.github, env.context, env.core);
+	return Object.fromEntries(env.posted.map((s) => [s.sha, s]));
+}
+
+const ownHead = { repo: { full_name: OWN } };
+const pr = (number, body, sha, head = {}) => ({ number, body, head: { sha, ...ownHead, ...head } });
+
+process.env.COMPANION_CHECK_TOKEN = '';
+globalThis.fetch = async () => ({ ok: false, status: 403 });
+
+// --- schedule sweep ---
+const sweepPrs = [
+	pr(623, 'Docs.\n\nDepends-on: HarperFast/harper#2147\n', 'aaa'),
+	pr(700, 'plain docs PR, no deps', 'bbb'),
+	pr(701, 'Depends-on: https://github.com/HarperFast/harper/pull/2000, documentation#600', 'ccc'),
+	pr(702, 'depends-on: HarperFast/harper#1999', 'ddd'),
+	pr(703, 'Depends-on: HarperFast/harper-pro#512', 'eee'),
+	pr(704, 'Depends-on: harper#1500', 'fff'), // repo#N shorthand
+	pr(705, 'Depends-on: the harper PR', 'ggg'), // unparseable -> failure
+	pr(706, 'Depends-on: HarperFast/harper#666', 'hhh'), // 500 -> unreadable, no crash
+	pr(707, `Depends-on: ${Array.from({ length: 12 }, (_, i) => `HarperFast/harper#${i + 1}`).join(', ')}`, 'iii'),
+	pr(708, 'Depends-on: harper#1500, HarperFast/harper#1500', 'jjj'), // dedupe -> 1 dep
+	pr(709, 'Depends-on: HarperFast/harper#2147 (the pagination PR)', 'res1'), // residue -> failure
+	pr(710, 'Depends-on:', 'res2'), // empty marker -> failure
+	pr(711, 'Depends-on: ../../evil/x#1', 'res3'), // traversal segments -> failure
+	pr(712, 'no marker, stale pending from removed marker', 'heal'), // heals to success
+	pr(713, 'Depends-on: harper#1500', 'memo'), // same dep as 704: memoized
+];
+const sweep = makeEnv('schedule', sweepPrs);
+const bySha = await run(sweep);
+
+assert.equal(bySha.aaa.state, 'pending');
+assert.match(bySha.aaa.description, /Waiting on HarperFast\/harper#2147/);
+assert.equal(bySha.bbb.state, 'success', 'sweep backfills no-marker PRs');
+assert.equal(bySha.ccc.state, 'success');
+assert.match(bySha.ccc.description, /harper#2000.*documentation#600/);
+assert.equal(bySha.ddd, undefined, 'unchanged status must not repost');
+assert.equal(bySha.eee.state, 'pending');
+assert.match(bySha.eee.description, /Cannot read HarperFast\/harper-pro#512.*404.*TOKEN needed/);
+assert.equal(bySha.fff.state, 'success', 'repo#N shorthand resolves in own org');
+assert.equal(bySha.ggg.state, 'failure', 'unparseable marker fails closed');
+assert.match(bySha.ggg.description, /unparseable/i);
+assert.equal(bySha.hhh.state, 'pending', 'HTTP 500 must degrade, not crash');
+assert.match(bySha.hhh.description, /Cannot read HarperFast\/harper#666 \(500\)/);
+assert.equal(bySha.iii.state, 'failure', 'dep cap enforced');
+assert.equal(bySha.jjj.state, 'success', 'duplicates deduped');
+assert.match(bySha.jjj.description, /^All companion PRs merged \(HarperFast\/harper#1500\)$/);
+assert.equal(bySha.res1.state, 'failure', 'non-ref residue on marker line fails closed');
+assert.equal(bySha.res2.state, 'failure', 'empty marker fails closed');
+assert.equal(bySha.res3.state, 'failure', 'path-traversal segments fail closed');
+assert.equal(bySha.heal.state, 'success', 'sweep heals stale pending after marker removal');
+assert.equal(bySha.memo.state, 'success');
+assert.equal(
+	sweep.getCalls.filter((k) => k === 'HarperFast/harper#1500').length,
+	1,
+	'dep lookups memoized within a run'
+);
+assert.equal(sweep.core.failed, undefined, 'no PR-level failures expected');
+assert.ok(sweep.posted.every((s) => s.context === 'companion-check' && s.description.length <= 140));
+
+// --- pull_request_target: no-marker PR gets success, no sweep re-read ---
+const evt = makeEnv('pull_request_target', [], pr(700, 'plain', 'bbb'));
+const evtBySha = await run(evt);
+assert.equal(evtBySha.bbb.state, 'success');
+assert.equal(evtBySha.bbb.description, 'No companion dependencies');
+
+// --- sweep race guard: body changed between list and post -> skip ---
+const stale = pr(720, 'Depends-on: HarperFast/harper#2147', 'kkk');
+const race = makeEnv('schedule', [stale]);
+const origGet = race.github.rest.pulls.get;
+race.github.rest.pulls.get = async (args) =>
+	args.repo === 'documentation' ? { data: pr(720, 'edited body', 'kkk') } : origGet(args);
+const raceBySha = await run(race);
+assert.equal(raceBySha.kkk, undefined, 'sweep must not post over a changed PR');
+
+// --- error mid-PR must downgrade a would-be-stale status to pending ---
+const errEnv = makeEnv('pull_request_target', [], pr(721, 'Depends-on: HarperFast/harper#2147', 'err1'));
+errEnv.github.rest.repos.listCommitStatusesForRef = async () => {
+	throw new Error('api down');
+};
+const errBySha = await run(errEnv);
+assert.equal(errBySha.err1.state, 'pending', 'failed refresh posts pending, not silence');
+assert.match(errBySha.err1.description, /errored/);
+assert.match(errEnv.core.failed, /1 PR/);
+
+// --- secret guards ---
+process.env.COMPANION_CHECK_TOKEN = 'tok';
+let fetched = [];
+globalThis.fetch = async (url) => (fetched.push(url), { ok: false, status: 404 });
+
+// foreign org: secret withheld
+const foreign = makeEnv('pull_request_target', [], pr(730, 'Depends-on: HarperFast/../evil#1', 'lll'));
+await run(foreign); // traversal caught in parse; now a clean foreign ref:
+const foreign2 = makeEnv('pull_request_target', [], {
+	number: 731,
+	body: 'Depends-on: https://github.com/evilorg/private/pull/1',
+	head: { sha: 'mmm', repo: { full_name: OWN } },
+});
+const foreignBySha = await run(foreign2);
+assert.equal(fetched.length, 0, 'secret must not be sent for foreign orgs');
+assert.equal(foreignBySha.mmm.state, 'pending');
+
+// fork PR: secret withheld even for same-org refs
+const fork = makeEnv('pull_request_target', [], {
+	number: 732,
+	body: 'Depends-on: HarperFast/harper-pro#512',
+	head: { sha: 'nnn', repo: { full_name: 'outsider/documentation' } },
+});
+const forkBySha = await run(fork);
+assert.equal(fetched.length, 0, 'secret must not be sent for fork PRs');
+assert.equal(forkBySha.nnn.state, 'pending');
+
+// non-fork same-org: secret used; token-confirmed 404 -> failure
+const typo = makeEnv('pull_request_target', [], pr(733, 'Depends-on: HarperFast/ghost#1', 'ooo'));
+const typoBySha = await run(typo);
+assert.equal(fetched.length, 1, 'secret used for same-org non-fork refs');
+assert.equal(typoBySha.ooo.state, 'failure', 'token-confirmed 404 fails, not pending');
+assert.match(typoBySha.ooo.description, /not found/);
+process.env.COMPANION_CHECK_TOKEN = '';
+
+console.log('PASS: all companion-check scenarios correct');

--- a/scripts/companion-check.test.mjs
+++ b/scripts/companion-check.test.mjs
@@ -7,11 +7,16 @@ const yaml = readFileSync(
 	process.argv[2] || new URL('../.github/workflows/companion-check.yaml', import.meta.url),
 	'utf8'
 );
-const script = yaml
-	.split('\n')
-	.filter((l) => /^ {12}/.test(l) || l.trim() === '')
-	.map((l) => l.slice(12))
-	.join('\n');
+const scriptLines = [];
+let inScript = false;
+for (const line of yaml.split('\n')) {
+	if (!inScript) {
+		if (/^\s*script: \|/.test(line)) inScript = true;
+	} else if (line.trim() === '' || line.startsWith('            ')) {
+		scriptLines.push(line.slice(12));
+	} else break;
+}
+const script = scriptLines.join('\n');
 assert(script.includes('parseDeps'), 'script extraction failed');
 
 const OWN = 'HarperFast/documentation';
@@ -180,6 +185,7 @@ assert.equal(fetched.length, 0, 'secret must not be sent for foreign orgs');
 assert.equal(foreignBySha.mmm.state, 'failure');
 
 // fork PR: secret withheld even for same-org refs
+fetched = [];
 const fork = makeEnv('pull_request_target', [], {
 	number: 732,
 	body: 'Depends-on: HarperFast/harper-pro#512',
@@ -190,6 +196,7 @@ assert.equal(fetched.length, 0, 'secret must not be sent for fork PRs');
 assert.equal(forkBySha.nnn.state, 'failure', 'blocks without leaking; message explains');
 
 // non-fork same-org: secret used; token-confirmed 404 -> failure
+fetched = [];
 const typo = makeEnv('pull_request_target', [], pr(733, 'Depends-on: HarperFast/ghost#1', 'ooo'));
 const typoBySha = await run(typo);
 assert.equal(fetched.length, 1, 'secret used for same-org non-fork refs');

--- a/scripts/companion-check.test.mjs
+++ b/scripts/companion-check.test.mjs
@@ -114,13 +114,13 @@ assert.equal(bySha.bbb.state, 'success', 'sweep backfills no-marker PRs');
 assert.equal(bySha.ccc.state, 'success');
 assert.match(bySha.ccc.description, /harper#2000.*documentation#600/);
 assert.equal(bySha.ddd, undefined, 'unchanged status must not repost');
-assert.equal(bySha.eee.state, 'pending');
-assert.match(bySha.eee.description, /Cannot read HarperFast\/harper-pro#512.*404.*TOKEN needed/);
+assert.equal(bySha.eee.state, 'failure', 'definitive 404 without secret blocks as not-found');
+assert.match(bySha.eee.description, /not found or inaccessible/);
 assert.equal(bySha.fff.state, 'success', 'repo#N shorthand resolves in own org');
 assert.equal(bySha.ggg.state, 'failure', 'unparseable marker fails closed');
 assert.match(bySha.ggg.description, /unparseable/i);
 assert.equal(bySha.hhh.state, 'pending', 'HTTP 500 must degrade, not crash');
-assert.match(bySha.hhh.description, /Cannot read HarperFast\/harper#666 \(500\)/);
+assert.match(bySha.hhh.description, /^Cannot read HarperFast\/harper#666 \(500\)$/);
 assert.equal(bySha.iii.state, 'failure', 'dep cap enforced');
 assert.equal(bySha.jjj.state, 'success', 'duplicates deduped');
 assert.match(bySha.jjj.description, /^All companion PRs merged \(HarperFast\/harper#1500\)$/);
@@ -177,7 +177,7 @@ const foreign2 = makeEnv('pull_request_target', [], {
 });
 const foreignBySha = await run(foreign2);
 assert.equal(fetched.length, 0, 'secret must not be sent for foreign orgs');
-assert.equal(foreignBySha.mmm.state, 'pending');
+assert.equal(foreignBySha.mmm.state, 'failure');
 
 // fork PR: secret withheld even for same-org refs
 const fork = makeEnv('pull_request_target', [], {
@@ -187,7 +187,7 @@ const fork = makeEnv('pull_request_target', [], {
 });
 const forkBySha = await run(fork);
 assert.equal(fetched.length, 0, 'secret must not be sent for fork PRs');
-assert.equal(forkBySha.nnn.state, 'pending');
+assert.equal(forkBySha.nnn.state, 'failure', 'blocks without leaking; message explains');
 
 // non-fork same-org: secret used; token-confirmed 404 -> failure
 const typo = makeEnv('pull_request_target', [], pr(733, 'Depends-on: HarperFast/ghost#1', 'ooo'));


### PR DESCRIPTION
Adds a `companion-check` commit status driven by `Depends-on:` markers in PR bodies, so a docs PR documenting an unmerged code change can be approved and armed for auto-merge, then land automatically once its companion PR (e.g. [harper#2147](https://github.com/HarperFast/harper/pull/2147)) merges. PRs without a marker get an immediate `success`, so once `companion-check` becomes a required check it never blocks ordinary docs PRs.

## For the human reviewer

1. **No-marker means silent success.** Chosen so the required check never gates ordinary docs PRs; the alternative (explicit `Depends-on: none` opt-out) reaches every author's habits. To cover the typo risk this creates, everything else fails closed: empty markers, unparseable refs, and any non-ref residue on a marker line all post `failure`. Reversible in-script.
2. **Poll, not push.** A 15-minute cron sweep polls companion state instead of the companion repos dispatching events here. Costs up to 15 minutes of merge latency and a modest API budget (~2 calls per open PR per sweep, dep lookups memoized and capped at 10 per PR); avoids wiring tokens/workflows into harper and harper-pro. Reversible later without changing the marker contract.
3. **Per-repo copy, not a reusable workflow.** This lands here and (separately) in harper-pro as [harper-pro#704](https://github.com/HarperFast/harper-pro/pull/704). If a third repo wants it, promoting to `HarperFast/.github` is the moment to deduplicate; the committed test harness makes drift detectable.
4. **Inline `github-script`, tested by extraction.** The ~150-line script stays in the YAML (no build step, no action packaging); `scripts/companion-check.test.mjs` extracts it by its 12-space indent and runs 25+ scenario assertions, wired into the Validate matrix as `Workflow Tests`. The extraction is a stateful parse of the `script: |` block (until dedent) and asserts loudly if it comes back empty.
5. **`pull_request_target` with a secret in scope, on a public repo.** Mitigations: the workflow never checks out PR code, the body is only ever data inside `github-script`, and the optional `COMPANION_CHECK_TOKEN` is used exclusively for same-org refs on non-fork PRs — a fork PR referencing a private repo blocks with an explanatory failure rather than probing with the secret. A maintenance rule at the top of the file states the invariant.
6. **Definitive 404s fail red.** A companion that doesn't resolve (typo, private repo without the token, token lacking access) posts `failure` "not found or inaccessible" rather than an eternal `pending` blaming a token. Both states block; the failure is more honest about needing human attention.
7. **Accepted residuals:** a millisecond TOCTOU between the sweep's freshness re-read and its status write (commit statuses have no CAS; the surviving stale direction is `pending`, which blocks); markers inside fenced code blocks are parsed as live (quote the word, not the marker form, when writing about it); statuses (not check runs) were chosen for required-check simplicity, so there is no re-run button — the 15-minute sweep or a `workflow_dispatch` is the retry path.

Not in this PR (needs repo admin, after merge): enable the `companion-check` required status check in branch protection, run one `workflow_dispatch` backfill sweep, and optionally add `COMPANION_CHECK_TOKEN` (fine-grained PAT or app token with PR read on harper-pro) for docs PRs that depend on private-repo PRs. Repo auto-merge (`allow_auto_merge`) is already enabled.

## Verification

`npm run test:workflows` (added to the Validate matrix) passes: 25+ assertions over the extracted production script covering marker parsing (all three documented forms, shorthand, dedupe, cap, empty/partial/traversal markers failing closed), state reduction (merged/open/closed/missing/unreadable precedence), sweep semantics (no-repost dedup, no-marker backfill, dropped-webhook healing, race-guard skip on changed PRs), error isolation (HTTP 500 degrades to pending; a thrown refresh posts pending rather than preserving stale success), and secret guards (withheld for foreign orgs and fork PRs). `npm run format:check` clean. The workflow itself cannot run end-to-end from this branch (`schedule` fires on the default branch only, and the status context becomes selectable in branch protection only after a first `main` run) — post-merge verification is a manual `workflow_dispatch` sweep plus arming [#623](https://github.com/HarperFast/documentation/pull/623) as the live trial.

## Review coverage

Authored by Claude Fable 5. Cross-model review across 4 rounds (full @ f2c4478, deltas @ 2fd988e / e6093a1, final @ 71750b6 = HEAD): codex graded leg ✓ (gpt-5.6-sol @ HEAD), gemini via agy (default model) ✓ every round, Harper-domain adjudication ✓ (claude-opus-5, last @ e6093a1; pruned on the final narrow delta), cursor-grok ✗ (output-format failure), cursor-composer ✗ (pruned round 1, format failure @ e6093a1). Verdict trail CHANGES → CHANGES → CHANGES → COMMENTS; the remaining findings are the accepted residuals in the ledger above.

<sub>Human-Review-Need: 4 @ b3681a151c96</sub>
