### PR TITLE
docs(cli): token credentials in the canonical auth precedence (v5.2.0)

### DIFF
--- a/reference/cli/authentication.md
+++ b/reference/cli/authentication.md
@@ -208,7 +208,7 @@ Expose the two values to the deploy step and no other credentials are needed:
 
 **Refresh behavior.** The CLI mints an operation token from the refresh token when none is supplied, and again whenever the supplied one has expired. A token refreshed from an environment variable is held in memory for that invocation only — nothing is written to `~/.harperdb/credentials.json`, because there is no file entry for an environment-supplied credential. If the refresh token itself is rejected, the command reports that and exits non-zero rather than falling back to another identity.
 
-**A blank token variable is an error, not a fallback.** If a namespace is set but empty — the usual shape of a misconfigured CI secret — the CLI says so and falls back to saved login credentials. It does not silently run as whoever last logged in on that machine.
+**A blank token variable is reported, then skipped.** If a namespace is set but empty — the usual shape of a misconfigured CI secret — the CLI warns and continues down the precedence list, so the run proceeds under the saved `harper login` token if that machine has one. The warning is the only thing separating this from silently deploying as whoever last logged in, so treat it as a failure signal in CI rather than assuming a blank secret stops the run.
 
 **Lifetimes.** Operation tokens expire after `authentication.operationTokenTimeout` (default `1d`) and refresh tokens after `authentication.refreshTokenTimeout` (default `30d`). The pipeline needs a new refresh token when that window closes.
 

--- a/reference/cli/authentication.md
+++ b/reference/cli/authentication.md
@@ -42,10 +42,13 @@ For remote Operations API commands, the CLI uses the first complete authenticati
 2. Credentials embedded in the `target` URL
 3. `HARPER_CLI_USERNAME` and `HARPER_CLI_PASSWORD` environment variables
 4. Legacy `CLI_TARGET_USERNAME` and `CLI_TARGET_PASSWORD` environment variables
-5. A token saved by `harper login`
-6. `username=` and `password=` operation parameters (legacy fallback)
+5. `HARPER_CLI_OPERATION_TOKEN` and `HARPER_CLI_REFRESH_TOKEN` environment variables, or their legacy `CLI_TARGET_` equivalents — see [Token credentials for CI/CD](#token-credentials-for-cicd)
+6. A token saved by `harper login`
+7. `username=` and `password=` operation parameters (legacy fallback)
 
 Credentials are resolved as a pair and are never combined across sources. An incomplete pair supplied with dedicated authentication parameters or in the target URL causes the command to fail. An incomplete environment-variable pair is skipped with a warning so that a saved login token can still be used.
+
+Entries 5 and 6 authenticate with a bearer token and apply to **remote targets only**. A local operation goes over the domain socket, which the server already trusts, so token environment variables are deliberately ignored there — a token minted for one instance would otherwise be attached to every local `harper` command in that shell and rejected.
 
 Before v5.2.0, `username=` and `password=` operation parameters took precedence over environment variables and saved login tokens. This could authenticate an operation as the wrong user when those fields were part of the operation payload, such as the user being created by `add_user`.
 
@@ -94,8 +97,14 @@ Starting in v5.2.0, a complete environment-variable credential pair takes preced
 - `HARPER_CLI_TARGET` - Sets the default `target` for CLI commands. `CLI_TARGET` is the legacy equivalent.
 - `HARPER_CLI_USERNAME` and `HARPER_CLI_PASSWORD` - Preferred credential pair for the target.
 - `CLI_TARGET_USERNAME` and `CLI_TARGET_PASSWORD` - Lower-priority legacy credential pair.
+- `HARPER_CLI_REFRESH_TOKEN` - Long-lived token the CLI exchanges for a fresh operation token on each run. `CLI_TARGET_REFRESH_TOKEN` is the legacy equivalent.
+- `HARPER_CLI_OPERATION_TOKEN` - A short-lived operation token supplied directly, for callers that mint their own.
 
 Each credential namespace is independent. For example, the CLI never combines `HARPER_CLI_USERNAME` with `CLI_TARGET_PASSWORD`. If either namespace supplies only a username or only a password, that incomplete pair is skipped with a warning.
+
+The same rule holds for tokens, and for the same reason: whichever namespace supplies a token owns both halves of it. If `HARPER_CLI_OPERATION_TOKEN` were allowed to pair with `CLI_TARGET_REFRESH_TOKEN`, commands would run as the first identity until its operation token expired and then silently continue as the second.
+
+For a pipeline, prefer a token over `HARPER_CLI_PASSWORD`: it is scoped to authentication, it can be revoked without changing the account password, and it cannot be used to log in interactively. See [Token credentials for CI/CD](#token-credentials-for-cicd).
 
 **Example `.env` file**:
 
@@ -161,6 +170,53 @@ harper add_user \
   password="$NEW_USER_PASSWORD" \
   target=https://prod-server.com:9925
 ```
+
+##### Token credentials for CI/CD
+
+<VersionBadge version="v5.2.0" />
+
+Rather than storing an admin password in your CI provider, log in once locally and hand CI a **refresh token**. The CLI mints a fresh, short-lived operation token from it on every run, so the only durable secret the pipeline holds is a revocable token.
+
+`harper login --for-ci` writes the variables CI needs to **stdout** in `.env` format — and nothing else, so the output pipes cleanly. Everything a human reads (banner, prompts, status, warnings) goes to stderr:
+
+```bash
+# Set both GitHub Actions secrets in one command — the token is never displayed
+harper login --for-ci | gh secret set --env-file -
+
+# Or copy them to the clipboard to paste in by hand
+harper login --for-ci | pbcopy
+```
+
+The block it emits:
+
+```bash
+HARPER_CLI_TARGET=https://example.com:9925/
+HARPER_CLI_REFRESH_TOKEN=eyJhbGciOi...
+```
+
+Because stdout carries only these two lines, the token never appears on screen or in your shell history — which is not true of copying it out of terminal output by hand. If the cluster returns no refresh token, the command fails rather than emitting a half-block that would "succeed" at storing nothing.
+
+Expose the two values to the deploy step and no other credentials are needed:
+
+```yaml
+- name: Deploy
+  run: harper deploy project=my-app restart=true replicated=true
+  env:
+    HARPER_CLI_TARGET: ${{ secrets.HARPER_CLI_TARGET }}
+    HARPER_CLI_REFRESH_TOKEN: ${{ secrets.HARPER_CLI_REFRESH_TOKEN }}
+```
+
+**Refresh behavior.** The CLI mints an operation token from the refresh token when none is supplied, and again whenever the supplied one has expired. A token refreshed from an environment variable is held in memory for that invocation only — nothing is written to `~/.harperdb/credentials.json`, because there is no file entry for an environment-supplied credential. If the refresh token itself is rejected, the command reports that and exits non-zero rather than falling back to another identity.
+
+**A blank token variable is an error, not a fallback.** If a namespace is set but empty — the usual shape of a misconfigured CI secret — the CLI says so and falls back to saved login credentials. It does not silently run as whoever last logged in on that machine.
+
+**Lifetimes.** Operation tokens expire after `authentication.operationTokenTimeout` (default `1d`) and refresh tokens after `authentication.refreshTokenTimeout` (default `30d`). The pipeline needs a new refresh token when that window closes.
+
+:::warning
+**Each user holds only one valid refresh token at a time.** Harper stores a single refresh-token hash per user, so minting a new one revokes that user's previous token. A routine local `harper login` as the same account will break a pipeline holding the older token, and the failure only surfaces on the pipeline's next refresh.
+
+Create a **dedicated CI user** and run `harper login --for-ci` as that user. That scopes the pipeline's permissions to what it actually needs, and lets you revoke its access without disturbing anyone else.
+:::
 
 #### Method 3: Dedicated Authentication Parameters
 

--- a/reference/cli/commands.md
+++ b/reference/cli/commands.md
@@ -155,6 +155,7 @@ harper login <URL>
 **Optional Parameters**:
 
 - `<URL>` - The URL of the Harper instance to log in to.
+- `--for-ci` - After logging in, print CI/CD credentials to stdout. Available since v5.2.0.
 
 **Prompts**:
 
@@ -163,6 +164,22 @@ You'll be asked to type in the following information:
 - `<URL>` - If a URL parameter is not provided, you'll be prompted to enter the URL of the Harper instance to log in to.
 - `<username>` - Harper admin username.
 - `<password>` - Harper admin password.
+
+#### `--for-ci`
+
+<VersionBadge version="v5.2.0" />
+
+Prints `HARPER_CLI_TARGET` and `HARPER_CLI_REFRESH_TOKEN` to **stdout** in `.env` format — and nothing else, so the output pipes directly into a secret store without the token being displayed. Everything else (banner, prompts, status, warnings) goes to stderr:
+
+```bash
+# Set both GitHub Actions secrets in one command
+harper login --for-ci | gh secret set --env-file -
+
+# Or copy them to paste in by hand
+harper login --for-ci | pbcopy
+```
+
+Run this as a **dedicated CI user**, not your own account: a user holds only one valid refresh token at a time, so issuing one for CI revokes any other token that user already had. See [Token credentials for CI/CD](authentication.md#token-credentials-for-cicd) for how the CLI consumes these variables and where they sit in authentication precedence.
 
 ### `harper logout`
 

--- a/release-notes/v5-lincoln/5.2.md
+++ b/release-notes/v5-lincoln/5.2.md
@@ -58,6 +58,14 @@ New `write-transaction-queue-depth` and `read-transaction-queue-depth` metrics r
 
 CLI Operations API commands now accept dedicated `auth_username=` and `auth_password=` parameters, allowing commands such as `add_user` and `alter_user` to authenticate as an administrator while keeping the affected user's `username=` and `password=` in the operation payload. Environment-variable credentials and saved `harper login` tokens now take precedence over the legacy `username=` and `password=` authentication fallback. Credential pairs are also resolved within one environment-variable namespace, preventing a username from `HARPER_CLI_*` from being combined with a password from legacy `CLI_TARGET_*` variables. See [CLI Authentication](/reference/v5/cli/authentication#authentication-precedence).
 
+### Token Credentials for CI/CD
+
+A pipeline no longer needs an admin password. `HARPER_CLI_REFRESH_TOKEN` supplies a long-lived token that the CLI trades for a fresh, short-lived operation token on every run, and `HARPER_CLI_OPERATION_TOKEN` supplies one directly for callers that mint their own. Both rank above a saved `harper login` token and above the legacy `username=`/`password=` fallback, so a configured CI identity is authoritative on a runner that also has a developer's login. A token refreshed from an environment variable is held in memory for that invocation only.
+
+`harper login --for-ci` provisions them: it prints `HARPER_CLI_TARGET` and `HARPER_CLI_REFRESH_TOKEN` to stdout in `.env` format and nothing else, so `harper login --for-ci | gh secret set --env-file -` stores both without the token being displayed.
+
+Because Harper keeps one refresh-token hash per user, issuing a token revokes that user's previous one — run `--for-ci` as a dedicated CI user rather than your own account. See [Token credentials for CI/CD](/reference/v5/cli/authentication#token-credentials-for-cicd).
+
 ## HTTP
 
 ### Middleware routing and ordering


### PR DESCRIPTION
Documents the CI/CD token credentials that shipped in **v5.2.0** via [harper#1876](https://github.com/HarperFast/harper/pull/1876) and never reached the reference docs.

Split out of [#599](https://github.com/HarperFast/documentation/pull/599), where this content was blocked behind four unmerged upstream PRs. It has no upstream dependency of its own — the behavior is live in v5.2.0 and has been since 2026-07-31 — so it can be reviewed and merged independently. That answers the first of @Ethan-Arrowood's two sequencing questions on #599.

## Why this was worth separating

`HARPER_CLI_REFRESH_TOKEN` and `HARPER_CLI_OPERATION_TOKEN` are the credentials the CLI is meant to use in a pipeline, and the **Authentication Precedence** list — the one place that states which credential wins — stopped at the saved `harper login` token. A reader following the docs to set up CI had no way to learn the two variables exist, let alone where they rank.

## What changed

**`reference/cli/authentication.md`**

- Bearer tokens slotted into the existing numbered precedence list at **position 5**, above the saved login token and above the legacy `username=`/`password=` fallback. Folded into the canonical list rather than stated as a second, competing paragraph, so the order is given once.
- Added to Method 2's supported-variable list, with the namespace rule: whichever prefix supplies a token owns both halves of it.
- New **Token credentials for CI/CD** subsection covering `harper login --for-ci`, the GitHub Actions step shape, refresh behavior, lifetimes, and the one-refresh-token-per-user warning.

**`reference/cli/commands.md`** — `--for-ci` on `harper login`, including the stdout/stderr split that makes `| gh secret set --env-file -` work without displaying the token.

## Behavior documented that was only visible in the source

These are the parts a reader cannot infer, and the reason the section runs longer than a variable list:

- **Token variables are ignored for local operations.** A local command goes over the domain socket, which the server already trusts via `bypassLocalAuth` — and that bypass is an `else if` on "no Authorization header present". Attaching a bearer token to a local request opts out of the trust and gets validated instead, 401ing on a token minted for another cluster. Since these variables are meant to persist across a whole CI job or a developer's shell, reading them unconditionally would break every local `harper` command in that environment.
- **A token namespace is selected as a unit.** If `HARPER_CLI_OPERATION_TOKEN` could pair with `CLI_TARGET_REFRESH_TOKEN`, commands would run as the first identity until its operation token expired and then silently continue as the second.
- **A set-but-blank namespace reports and falls back** to saved login credentials rather than silently running as whoever last logged in on that machine — the usual shape of a misconfigured CI secret.
- **An env-sourced refreshed token stays in memory.** There is no credentials-file entry to persist it to, unlike a token refreshed from `~/.harperdb/credentials.json`.
- **One refresh-token hash per user.** `createTokens` overwrites `hdb_user.refresh_token` and refresh validation accepts only that hash, so minting a token for CI revokes whatever token that user already held — invisibly, until the other holder's next refresh 401s. This is why the section pushes a dedicated CI user rather than mentioning it as a nicety. Named, independently revocable credentials are [harper#2018](https://github.com/HarperFast/harper/issues/2018).

## Verification

Checked against harper **v5.2.2**, not against the PR that introduced the feature:

| Claim | Source |
| --- | --- |
| Precedence order, local-target gate, namespace unit, blank-namespace fallback | `bin/cliOperations.ts` |
| In-memory vs. persisted refresh | `refreshExpiredOperationToken`, `persistKey` |
| `--for-ci` emits two lines on stdout; fails rather than emitting a half-block | `bin/login.ts` |
| `1d` / `30d` lifetime defaults | `config/configUtils.ts` |
| One refresh-token hash per user | `security/tokenAuthentication.ts` |

`npm run build` and `npm run format:check` are clean. The build reports two broken anchors; both are pre-existing on `main` (verified by building `main` with these changes stashed) and neither is in a file this PR touches.

## Notes for review

- No companion marker: nothing here is gated on an unmerged PR, so it gets an immediate pass once [#629](https://github.com/HarperFast/documentation/pull/629)'s check becomes required.
- Opened as a draft only to match the rest of this stack. Unlike the others there is nothing to wait for — promote it whenever you want it reviewed.
- The v5.2.0 badge on the `--for-ci` heading is a real release, not a placeholder. The rest of the deploy stack has moved to v5.3.0 (see #599).

_Description drafted by Claude Code (Opus 5)._
