### PR TITLE
docs(roles): state the limits of the operations allowlist

### DIFF
--- a/reference/users-and-roles/overview.md
+++ b/reference/users-and-roles/overview.md
@@ -79,6 +79,14 @@ The `operations` field in a permission object restricts which Operations API cal
 
 Operations normally restricted to `super_user` can be selectively granted by including them in the list. If `operations` is not set, the role can call any non-`super_user` operation, subject to table CRUD permissions.
 
+The field scopes an ordinary role; it is not a way to narrow an administrator. Three limits follow from that, and each one surprises people:
+
+- **`super_user` and `cluster_user` roles cannot carry an allowlist at all.** `add_role` and `alter_role` reject any permission that sets either flag alongside other keys, so the combination is a validation error rather than a restricted admin. Authorization also clears a `super_user` role before the allowlist is consulted.
+- **`structure_user` roles bypass the allowlist for DDL only.** `create_table`, `create_attribute`, `drop_table`, and `drop_attribute` are reachable regardless of the list — plus `create_database`/`drop_database` when `structure_user` is `true`. When it is an array of database names, that carve-out applies only to those databases. Every other operation is still gated normally.
+- **`sql` is not gated by this field.** SQL statements are authorized against table CRUD permissions on their own path, so listing `sql` neither grants nor restricts them, and omitting it does not prevent a role from running SQL. This matters when reading the `read_only` and `standard_user` groups below, both of which include the name.
+
+The value must be an array of strings. A non-array value is rejected on write, and a role that already holds one (for example a pre-5.0 role that granted a database named `operations`) can prevent the instance from loading its user cache — see [HarperFast/harper#2194](https://github.com/HarperFast/harper/issues/2194).
+
 **Permission Groups**
 
 Groups expand to a predefined set of operations and can be mixed with individual operation names:


### PR DESCRIPTION
Companion to HarperFast/studio#1628, which surfaces `permission.operations` in the Studio roles UI. Building that UI meant establishing the field's real semantics against the Harper source, and several of them contradict a natural reading of this page — I got each one wrong first and had them caught in review.

## What changes

The two-gate description reads as universal ("any unlisted operation is denied"), so the obvious next thought is a restricted super user. Three limits are now stated explicitly:

- **`super_user`/`cluster_user` + `operations` is a validation error.** `validateNoSUPerms` rejects any multi-key permission setting either flag. Authorization also returns early for a `super_user` role before reaching the allowlist gate, so even a stored one would not narrow it.
- **`structure_user` bypasses the allowlist for DDL only** — the four table/attribute operations, plus create/drop database for the boolean form; the array form scopes that to its listed databases. Everything else is still gated.
- **`sql` is authorized on its own path** (`checkASTPermissions`/`verifyPermsAST`), which never consults the allowlist. Worth stating plainly because `sql` appears in both `read_only` and `standard_user`, so the groups imply the opposite.

Plus a pointer to HarperFast/harper#2194 for the non-array case, since a role carrying one can stop the instance loading its user cache.

## Verification

Read against harper `v5.2.2` (`utility/operation_authorization.ts`, `validation/role_validation.ts`, `security/user.ts`, `server/serverHelpers/serverUtilities.ts`); the `sql` and `structure_user` claims were also exercised against the compiled `dist/`. No behavior change here — this documents what 5.x already does.

## Review coverage

Written by an LLM (Claude Fable 5). Prose-only change to one file; `prettier --check` clean. The underlying findings were reviewed by @cb1kenobi and @kriszyp on studio#1628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)