### PR TITLE
Document node.hostname config option (must be a bare hostname)

### DIFF
--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -214,7 +214,7 @@ node:
   hostname: server-one
 ```
 
-- `hostname` — This node's identity. Must be a **bare hostname** (e.g. `server-one`) — **not** a URL and **not** `host:port`. Do not include a scheme (`https://`, `wss://`) or a port (`:9933`). This value becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node, so a scheme or port silently breaks certificate matching and replication rather than erroring. Harper logs a startup warning if `hostname` is configured as a URL or `host:port` value. If unset, the node name is derived from `replication.hostname`, the replication URL, or the TLS certificate common name.
+- `hostname` — This node's identity: it becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node. Must be a **bare hostname or IP literal** (e.g. `server-one`, `10.0.0.5`, or the unbracketed IPv6 form `::1`) — **not** a URL and **not** `host:port`. Harper **fails to start** if the value carries a scheme, port, path, credentials, query string, or fragment, is a bracketed IPv6 literal (`[::1]`), or is not a string; the startup error names the offending value and the reason. Earlier versions accepted such values and silently corrupted certificate matching and replication — a node configured as `http://host:9926` advertised and dialed a host literally named `http`. The same requirement applies to [`replication.hostname`](#replication). If unset, Harper uses the first valid bare host among `replication.hostname`, the host in `replication.url`, the TLS certificate common name, and the Operations API host, falling back to `127.0.0.1`.
 
 ---
 
@@ -231,7 +231,7 @@ replication:
     - wss://server-two:9933
 ```
 
-- `hostname` — This instance's hostname within the cluster
+- `hostname` — This instance's hostname within the cluster. Subject to the same bare hostname or IP literal requirement as [`node.hostname`](#node) — a URL, `host:port`, or non-string value fails startup. When both are set, `node.hostname` wins.
 - `url` — WebSocket URL peers use to connect to this instance
 - `databases` — Databases to replicate; _Default_: `"*"` (all). Each entry supports `name` and `sharded`
 - `routes` — Peer nodes; URL strings or `{hostname, port, startTime, revokedCertificates}` objects

--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -205,6 +205,19 @@ logging:
 
 ---
 
+## `node`
+
+This node's identity within the cluster. See [Replication](../replication/overview.md).
+
+```yaml
+node:
+  hostname: server-one
+```
+
+- `hostname` — This node's identity. Must be a **bare hostname** (e.g. `server-one`) — **not** a URL and **not** `host:port`. Do not include a scheme (`https://`, `wss://`) or a port (`:9933`). This value becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node, so a scheme or port silently breaks certificate matching and replication rather than erroring (see [harper#2218](https://github.com/HarperFast/harper/issues/2218)). Harper logs a startup warning if `hostname` is configured as a URL or `host:port` value (see [harper#2223](https://github.com/HarperFast/harper/pull/2223)). If unset, the node name is derived from `replication.hostname`, the replication URL, or the TLS certificate common name.
+
+---
+
 ## `replication`
 
 Native WebSocket-based replication (Plexus). Added in: v4.4.0. See [Replication](../replication/overview.md) and [Clustering](../replication/clustering.md).

--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -214,7 +214,7 @@ node:
   hostname: server-one
 ```
 
-- `hostname` — This node's identity. Must be a **bare hostname** (e.g. `server-one`) — **not** a URL and **not** `host:port`. Do not include a scheme (`https://`, `wss://`) or a port (`:9933`). This value becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node, so a scheme or port silently breaks certificate matching and replication rather than erroring (see [harper#2218](https://github.com/HarperFast/harper/issues/2218)). Harper logs a startup warning if `hostname` is configured as a URL or `host:port` value (see [harper#2223](https://github.com/HarperFast/harper/pull/2223)). If unset, the node name is derived from `replication.hostname`, the replication URL, or the TLS certificate common name.
+- `hostname` — This node's identity. Must be a **bare hostname** (e.g. `server-one`) — **not** a URL and **not** `host:port`. Do not include a scheme (`https://`, `wss://`) or a port (`:9933`). This value becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node, so a scheme or port silently breaks certificate matching and replication rather than erroring. Harper logs a startup warning if `hostname` is configured as a URL or `host:port` value. If unset, the node name is derived from `replication.hostname`, the replication URL, or the TLS certificate common name.
 
 ---
 

--- a/reference/configuration/options.md
+++ b/reference/configuration/options.md
@@ -214,7 +214,7 @@ node:
   hostname: server-one
 ```
 
-- `hostname` — This node's identity: it becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node. Must be a **bare hostname or IP literal** (e.g. `server-one`, `10.0.0.5`, or the unbracketed IPv6 form `::1`) — **not** a URL and **not** `host:port`. Harper **fails to start** if the value carries a scheme, port, path, credentials, query string, or fragment, is a bracketed IPv6 literal (`[::1]`), or is not a string; the startup error names the offending value and the reason. Earlier versions accepted such values and silently corrupted certificate matching and replication — a node configured as `http://host:9926` advertised and dialed a host literally named `http`. The same requirement applies to [`replication.hostname`](#replication). If unset, Harper uses the first valid bare host among `replication.hostname`, the host in `replication.url`, the TLS certificate common name, and the Operations API host, falling back to `127.0.0.1`.
+- `hostname` <VersionBadge type="changed" version="v5.3.0" /> — This node's identity: it becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach this node. Must be a **bare hostname or IP literal** (e.g. `server-one`, `10.0.0.5`, or the unbracketed IPv6 form `::1`) — **not** a URL and **not** `host:port`. Harper **fails to start** if the value carries a scheme, port, path, credentials, query string, or fragment, is a bracketed IPv6 literal (`[::1]`), or is not a string; the startup error names the offending value and the reason. Earlier versions accepted such values and silently corrupted certificate matching and replication — a node configured as `http://host:9926` advertised and dialed a host literally named `http`. The same requirement applies to [`replication.hostname`](#replication). If unset, Harper uses the first valid bare host among `replication.hostname`, the host in `replication.url`, the TLS certificate common name, and the Operations API host, falling back to `127.0.0.1`.
 
 ---
 
@@ -231,7 +231,7 @@ replication:
     - wss://server-two:9933
 ```
 
-- `hostname` — This instance's hostname within the cluster. Subject to the same bare hostname or IP literal requirement as [`node.hostname`](#node) — a URL, `host:port`, or non-string value fails startup. When both are set, `node.hostname` wins.
+- `hostname` <VersionBadge type="changed" version="v5.3.0" /> — This instance's hostname within the cluster. Subject to the same bare hostname or IP literal requirement as [`node.hostname`](#node) — a URL, `host:port`, or non-string value fails startup. When both are set, `node.hostname` wins.
 - `url` — WebSocket URL peers use to connect to this instance
 - `databases` — Databases to replicate; _Default_: `"*"` (all). Each entry supports `name` and `sharded`
 - `routes` — Peer nodes; URL strings or `{hostname, port, startTime, revokedCertificates}` objects

--- a/release-notes/v5-lincoln/5.3.md
+++ b/release-notes/v5-lincoln/5.3.md
@@ -1,0 +1,21 @@
+---
+title: '5.3'
+---
+
+# 5.3 Release Notes
+
+### Patch Releases
+
+All patch release notes for 5.3.x are available on the [releases page](https://github.com/HarperFast/harper/releases?q=v5.3&expanded=true).
+
+## Node Identity
+
+`node.hostname` and `replication.hostname` must now be a bare hostname or IP literal. This value is the node's identity — it becomes the node's TLS certificate common name and the host that replication advertises to peers and dials to reach the node — so a URL or `host:port` value corrupted certificate matching and replication without surfacing an error: a node configured as `http://host:9926` advertised and dialed a host literally named `http` ([harper#2218](https://github.com/HarperFast/harper/issues/2218)).
+
+Configuration validation now rejects these values at startup, so **an existing install whose `node.hostname` or `replication.hostname` is a URL, `host:port`, or a non-string value will fail to start until it is corrected to a bare host.** The startup error names the offending value and the reason it was rejected. A bare hostname (`server-one`), an IPv4 literal (`10.0.0.5`), and an unbracketed IPv6 literal (`::1`) are valid; a scheme, port, path, credentials, query string, fragment, bracketed IPv6 literal (`[::1]`), or non-string value is rejected. Route entries under `replication.routes` are unaffected and may still be URLs.
+
+When `node.hostname` is unset, Harper resolves the identity to the first valid bare host among `replication.hostname`, the host in `replication.url`, the TLS certificate common name, and the Operations API host, falling back to `127.0.0.1`. A derived source that is empty or unusable is skipped rather than failing startup.
+
+Replication URLs now also bracket a bare IPv6 literal correctly (`::1` becomes `ws://[::1]:9933`), which the URL parser previously rejected.
+
+See [Configuration Options](/reference/v5/configuration/options#node).


### PR DESCRIPTION
Documents the `node` configuration section, which was missing from [Configuration Options](https://docs.harper.fast/reference/configuration/options) even though that page bills itself as covering *all* `harper-config.yaml` top-level sections, and records the node-identity behavior change that shipped in HarperFast/harper#2223.

`node.hostname` is this node's *identity*, not a URL: it becomes the node's TLS certificate common name and the host replication advertises to peers and dials to reach the node. A URL or `host:port` value silently corrupted both — a node configured as `http://host:9926` advertised and dialed a host literally named `http` (HarperFast/harper#2218).

**Companion to HarperFast/harper#2223, which is now merged.** That PR landed as a *loud rejection at the config boundary*, not the warn-only change it was originally scoped as, so this docs PR was rewritten to match what actually shipped.

## What this documents

- **New `## node` section** in the config reference, placed immediately before `## replication` (identity is defined right before the section that consumes it).
- **The bare-host requirement, as enforced:** a bare hostname, IPv4 literal, or *unbracketed* IPv6 literal is valid; a scheme, port, path, credentials, query string, fragment, bracketed `[::1]`, or non-string value is rejected and **Harper fails to start**.
- **`replication.hostname` too** — harper#2223 put it under the same constraint (it previously accepted `string|number`), so its bullet was updated rather than left alone.
- **The full identity fallback chain** — `replication.hostname` → host in `replication.url` → certificate common name → Operations API host → `127.0.0.1`, skipping unusable derived sources.
- **`release-notes/v5-lincoln/5.3.md`** — a new page carrying the breaking-change entry, since an install with a URL/`host:port` hostname will fail to boot after upgrading.

## For the human reviewer

Two calls here are the author's judgment and are the places to push back:

1. **`v5.3.0` is an assumption, not a derived fact.** harper#2223 is merged to `main` but **no tag contains it** (latest is `v5.2.4`), so the ship version is not yet knowable from the repo. `v5.3.0` was chosen on the reasoning that a breaking change won't ship in a patch. If it actually ships as `v5.2.5`, both `<VersionBadge>` values and the release-notes filename need renaming before release.
2. **This publishes a `5.3` release-notes page before `5.3` exists.** The release-notes sidebar is autogenerated from the directory, so merging adds a visible "5.3" entry for an unreleased version. That is deliberate (it is where the breaking change belongs) but it does surface early — worth a second opinion on whether to hold this file until the release is cut.

Smaller notes:

- **No in-doc issue links in the reference page** (per the earlier review round), but the **release-notes page does link harper#2218** — that matches its own house style; `5.2.md` links harper#2049 the same way.
- **`node.url` is left undocumented.** It exists in the new Joi schema, but `node_url` appears only in `hdbTerms.ts` with no consumer, so documenting it would advertise dead surface.
- **`replication.routes` entries are explicitly called out as still accepting URLs** in the release notes, because the route schema is *not* bare-host constrained and readers will otherwise over-apply the new rule.
- **No admonition** was added to the config reference: that page has zero admonitions and is a flat quick-reference, so the boot-failure consequence is carried in bold inside the bullet instead.

## Verification

- `npm run build` — succeeds; document count 403 → 404 (the new 5.3 page). The two broken-anchor warnings it prints are pre-existing on unrelated pages (`backups/overview`, `release-notes/v5-lincoln/5.1`); the new `#node` / `#replication` anchors and the release-notes link into `/reference/v5/configuration/options#node` all resolve.
- `npm run format:write` then `npm run format:check` — clean.
- Rebased onto current `main` (12 commits) with no conflicts.
- Every documented claim was read off the merged core commit `08531e344`, not the PR description: `utility/nodeIdentity.ts` (`bareHostViolation` — the exact accept/reject set), `validation/configValidator.ts` (`bareHostConstraints` on both `node.hostname` and `replication.hostname`, and that route hostnames are unconstrained), and `server/nodeName.ts` (`getThisNodeName` fallback order).

## Review coverage

Authored by Claude Opus 4.8, revised by Claude Opus 5 after harper#2223 merged with different behavior. Accuracy verified by reading the merged core implementation directly. gemini-code-assist reviewed the earlier revision; its two comments were addressed (in-doc issue links removed; its suggested `v5.2.0` badge was declined as already-shipped and replaced with the `v5.3.0` badge above, with the caveat in item 1).
